### PR TITLE
DKMS and tripple boot guides

### DIFF
--- a/docs/guides/dkms.md
+++ b/docs/guides/dkms.md
@@ -1,0 +1,37 @@
+# Introduction
+
+This page explains how to install the kernel modules for the Keyboard, Audio, Touchbar and the Ambient Light sensor with DKMS. You will need a patched kernel.
+
+# Installing modules
+
+1. Install the `dkms` package
+2. Installing the BCE (Buffer Copy Engine) module for Keyboard and Audio
+	- You are on arch, get Aunali1's [apple-bce-dkms-git package](https://github.com/aunali1/apple-bce-arch/releases)
+	- Otherwise, `sudo git clone https://github.com/t2linux/apple-bce-drv /usr/src/apple-bce-r183.c884d9c`
+	- Use `sudo dkms install -m apple-bce -v r183.c884d9c`. Add `-k x.x.x-mbp` if you need to install for a specific kernel version.
+3. Installing the Touchbar and Ambient Light sensor modules
+	- `sudo git clone https://github.com/t2linux/apple-ib-drv /usr/src/apple-ibridge-0.1`
+	- Use `sudo dkms install -m apple-ibridge -v 0.1`. Add `-k x.x.x-mbp` if you need to install for a specific kernel version.
+4. Load the modules into the kernel
+
+```
+sudo modprobe apple_bce
+sudo modprobe apple_ib_tb
+sudo modprobe apple_ib_als
+```
+
+# Audio Configuration Files
+
+The Touchbar and keyboard should work.
+
+For audio, there are config files required, these can be found [here](https://gist.github.com/MCMrARM/c357291e4e5c18894bea10665dcebffb)
+
+If you are using a 2019 16 inch MBP, use [this](https://gist.github.com/kevineinarsson/8e5e92664f97508277fefef1b8015fba) set of files, as that laptop has 6 speakers.
+
+# Fixing Suspend
+
+Copy [this script](https://github.com/marcosfad/mbp-ubuntu/blob/master/files/suspend/rmmod_tb.sh) to `/lib/systemd/system-sleep/rmmod_tb.sh`
+
+# Issues
+
+The `apple_ib_als` module can cause issues, if you find your computer hanging at shutdown, or having BCE errors at boot, try blacklisting it `sudo sh -c "echo blacklist apple-ib-als" >> /etc/modprobe.d/blacklist.conf`

--- a/docs/guides/windows.md
+++ b/docs/guides/windows.md
@@ -30,12 +30,7 @@ If you are doing it manually:
 1. Format the main Linux partition(s) as ext4, btrfs, or whatever you intend to use.
 2. Mount your partitions, put the `EFI2` one at `/boot/efi` within your chroot.
 3. Install normally up until you install your bootloader, but don't forget to get a patched kernel and the correct dkms modules
-4. Within your chroot, do:
-
-```
-grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --no-nvram --removable
-```
-
+4. Within your chroot, do `grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --no-nvram --removable`
 5. There will now be an `EFI Boot` option in the MacOS Startup Manager (The menu you get by holding option at boot) which will boot Linux.
 
 ## Installing Windows when Linux is installed

--- a/docs/guides/windows.md
+++ b/docs/guides/windows.md
@@ -1,0 +1,54 @@
+# Introduction
+
+This page is a guide on getting windows and Linux both installed.
+
+
+# Installing Linux (With or without Windows already installed)
+
+### In MacOS
+
+Create partitions with Disk Utility
+- Make a 200Mb FAT32 partition, call it something like `EFI2`
+- Create your main partition(s) for Linux, make them MacOS Extended/HFS+ to stop Bootcamp Installer from thinking they are Windows. These will be erased and reformatted by your installer.
+
+### In your distro's installer
+
+If you are using an interactive installer:
+
+- Set the `EFI2` partition to be mounted at `/boot/efi`, don't use the partition labeled `EFI` located at `/dev/nvme0n1p1`, to avoid breaking the Windows bootloader stored there.
+- Your main partition that were formatted as MacOS Extended/HFS+ can be mounted at `/`.
+- If it fails to install the bootloader, open a terminal:
+	- Use `lsblk` or `mount` to find where your install's root partition is installed
+	- `chroot $that_partitions_mount_point_here`
+	- `grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --no-nvram --removable`
+- There will now be an `EFI Boot` option in the MacOS Startup Manager (The menu you get by holding option at boot) which will boot Linux.
+
+
+If you are doing it manually:
+
+- Format the main Linux partition(s) as ext4, btrfs, or whatever you intend to use.
+- Mount your partitions, put the `EFI2` one at `/boot/efi` within your chroot.
+- Install normally up until you install your bootloader, but don't forget to get a patched kernel and the correct dkms modules
+- Within your chroot, do:
+```
+grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --no-nvram --removable
+```
+- There will now be an `EFI Boot` option in the MacOS Startup Manager (The menu you get by holding option at boot) which will boot Linux.
+
+## Installing Windows when Linux is installed
+
+- If there are partitions labeled as `Microsoft Basic Data`, Bootcamp Assistant will think you have windows installed. 
+	- Use `sudo cfdisk /dev/nvme0n1` to change your Linux partitions to `Linux Filesystem` or whatever is appropriate. 
+- If your second EFI partition is labeled as `EFI System`, you'll need to use `cfdisk` again to make it not that, as the Windows installer fails if there are two.
+- Bootcamp should install windows normally. If you put your Linux bootloader on `/dev/nvme0n1p1`, Windows will replace it, and that's why a second EFI partition is ideal.
+
+
+## Quality of life things
+
+### Giving Options in MacOS Startup Manager Custom Icons
+
+Put an `icns` file with your desired icon in the top directory of the disk that the bootloader of the menu entry is on, and call it `.VolumeIcon.icns`.
+
+### Setting your Linux Partitions as `Linux Filesystem` type
+
+Use `sudo cfdisk /dev/nvme0n1` and change the type of your Linux partitions. This will show up when you do `diskutil list` in MacOS.

--- a/docs/guides/windows.md
+++ b/docs/guides/windows.md
@@ -3,11 +3,12 @@
 This page is a guide on getting windows and Linux both installed.
 
 
-# Installing Linux (With or without Windows already installed)
+## Installing Linux (With or without Windows already installed)
 
 ### In MacOS
 
-Create partitions with Disk Utility
+Create partitions with Disk Utility:
+
 - Make a 200Mb FAT32 partition, call it something like `EFI2`
 - Create your main partition(s) for Linux, make them MacOS Extended/HFS+ to stop Bootcamp Installer from thinking they are Windows. These will be erased and reformatted by your installer.
 
@@ -15,32 +16,33 @@ Create partitions with Disk Utility
 
 If you are using an interactive installer:
 
-- Set the `EFI2` partition to be mounted at `/boot/efi`, don't use the partition labeled `EFI` located at `/dev/nvme0n1p1`, to avoid breaking the Windows bootloader stored there.
-- Your main partition that were formatted as MacOS Extended/HFS+ can be mounted at `/`.
-- If it fails to install the bootloader, open a terminal:
-	- Use `lsblk` or `mount` to find where your install's root partition is installed
-	- `chroot $that_partitions_mount_point_here`
-	- `grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --no-nvram --removable`
-- There will now be an `EFI Boot` option in the MacOS Startup Manager (The menu you get by holding option at boot) which will boot Linux.
+1. Set the `EFI2` partition to be mounted at `/boot/efi`, don't use the partition labeled `EFI` located at `/dev/nvme0n1p1`, to avoid breaking the Windows bootloader stored there.
+2. Your main partition that were formatted as MacOS Extended/HFS+ can be mounted at `/`.
+3.  If it fails to install the bootloader, open a terminal:
+	1. Use `lsblk` or `mount` to find where your install's root partition is installed
+	2. `chroot $that_partitions_mount_point_here`
+	3. `grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --no-nvram --removable`
+4. There will now be an `EFI Boot` option in the MacOS Startup Manager (The menu you get by holding option at boot) which will boot Linux.
 
 
 If you are doing it manually:
 
-- Format the main Linux partition(s) as ext4, btrfs, or whatever you intend to use.
-- Mount your partitions, put the `EFI2` one at `/boot/efi` within your chroot.
-- Install normally up until you install your bootloader, but don't forget to get a patched kernel and the correct dkms modules
-- Within your chroot, do:
+1. Format the main Linux partition(s) as ext4, btrfs, or whatever you intend to use.
+2. Mount your partitions, put the `EFI2` one at `/boot/efi` within your chroot.
+3. Install normally up until you install your bootloader, but don't forget to get a patched kernel and the correct dkms modules
+4. Within your chroot, do:
+
 ```
 grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --no-nvram --removable
 ```
-- There will now be an `EFI Boot` option in the MacOS Startup Manager (The menu you get by holding option at boot) which will boot Linux.
+
+5. There will now be an `EFI Boot` option in the MacOS Startup Manager (The menu you get by holding option at boot) which will boot Linux.
 
 ## Installing Windows when Linux is installed
 
-- If there are partitions labeled as `Microsoft Basic Data`, Bootcamp Assistant will think you have windows installed. 
-	- Use `sudo cfdisk /dev/nvme0n1` to change your Linux partitions to `Linux Filesystem` or whatever is appropriate. 
-- If your second EFI partition is labeled as `EFI System`, you'll need to use `cfdisk` again to make it not that, as the Windows installer fails if there are two.
-- Bootcamp should install windows normally. If you put your Linux bootloader on `/dev/nvme0n1p1`, Windows will replace it, and that's why a second EFI partition is ideal.
+1. If there are partitions labeled as `Microsoft Basic Data`, Bootcamp Assistant will think you have windows installed. Use `sudo cfdisk /dev/nvme0n1` to change your Linux partitions to `Linux Filesystem` or whatever is appropriate. 
+2. If your second EFI partition is labeled as `EFI System`, you'll need to use `cfdisk` again to make it not that, as the Windows installer fails if there are two.
+3. Bootcamp should install windows normally. If you put your Linux bootloader on `/dev/nvme0n1p1`, Windows will replace it, and that's why a second EFI partition is ideal.
 
 
 ## Quality of life things


### PR DESCRIPTION
I've written guides on installing the DKMS modules for Keyboard, Audio, Touchbar and the Ambient Light sensor, and for putting the linux bootloader on a different efi partition to allow linux and windows to not fight over who gets the bootloader on /dev/nvme0n1