### PR TITLE
Separate Audio page, Links to new guides in FAQs, added to triple boot page

### DIFF
--- a/docs/distributions/manjaro/faq.md
+++ b/docs/distributions/manjaro/faq.md
@@ -1,8 +1,6 @@
 # Installing alongside Windows
 
-If you install Manjaro whilst Windows is also installed on your system, Manjaro will use the same Boot entry as the Windows Boot Manager on the macOS Boot Loader.
-
-After clicking on the Windows entry on the macOS bootloader, you will be taken to systemd-boot, from there you can choose if you would like to boot into Manjaro or use the Windows Boot Manager.
+If you want both Manjaro and Windows installed on your system, refer to this guide on [triple booting](https://wiki.t2linux.org/guides/windows/) as you install.
 
 # Issues Updating Because of the MBP Repository
 

--- a/docs/distributions/ubuntu/faq.md
+++ b/docs/distributions/ubuntu/faq.md
@@ -27,4 +27,4 @@ If you already have Bootcamp installed, you might notice that the boot option fo
 # Why isn't sound working?
 
 Due to issues in the mbp-ubuntu install process, there is no sound working after install. You'll have to set it up manually.
-efer to this guide on [audio configuration](https://wiki.t2linux.org/guides/audio-config).
+Refer to this guide on [audio configuration](https://wiki.t2linux.org/guides/audio-config).

--- a/docs/distributions/ubuntu/faq.md
+++ b/docs/distributions/ubuntu/faq.md
@@ -22,31 +22,9 @@ We've now changed the GRUB Bootloader settings, but we now need to update GRUB t
 
 # Installing alongside Windows
 
-If you already have Bootcamp installed, you might notice that the boot option for Bootcamp instead boots you into Ubuntu. This is because GRUB automatically shares with a Windows installation.
-
-Unlike other Linux distros, if you try to boot into it, it won't work and will stay at a black screen (confirmed with the 16,1 and might not be true with other models).
-There is a fix for this.
-
-While booted into Ubuntu, do the following:
-
-1. Open a terminal and type in ``sudo gdisk /dev/nvme0n1``.
-2. Press `x` for expert mode
-3. Press `n` to create a protective MBR
-4. Press `w` to write the partition and `y` to confirm
-5. If gdisk doesn't quit, press `q` to exit the command
-
-It should work now. Reboot into the GRUB Menu and try booting into Windows.
-
-(Credits to gbrow004 for documenting this fix on his [Gist](https://gist.github.com/gbrow004/096f845c8fe8d03ef9009fbb87b781a4#fixing-bootcampwindows))
+If you already have Bootcamp installed, you might notice that the boot option for Bootcamp instead boots you into Ubuntu. This is because GRUB automatically shares with a Windows installation. Follow [this guide on triple booting](https://wiki.t2linux.org/guides/windows/#if-windows-is-installed-first) to get windows working again.
 
 # Why isn't sound working?
 
 Due to issues in the mbp-ubuntu install process, there is no sound working after install. You'll have to set it up manually.
-
-For the 16,1 and higher, you can use the files from [here.](https://gist.github.com/kevineinarsson/8e5e92664f97508277fefef1b8015fba)
-
-For anything lower than the 16,1, you can use the files from [here.](https://gist.github.com/MCMrARM/c357291e4e5c18894bea10665dcebffb)
-
-The READMEs in the Gist should be clear on where to put the files. You can download them by clicking on Raw, right clicking, and press Save Page. Place them in an easy to access folder like your Downloads folder.
-
-Once that's done, reboot and sound should be working.
+efer to this guide on [audio configuration](https://wiki.t2linux.org/guides/audio-config).

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -25,4 +25,4 @@ LABEL="pulseaudio_end"```
 # Issues
 
 - Some people are unable to get audio input to work. You may have to use a seperate microphone.
-- All of apple's fancy tuning of the speakers is done in macos, we don't have anything like that at the moment.
+- All of apple's fancy tuning of the speakers is done in macOS, we don't have anything like that at the moment.

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -1,0 +1,28 @@
+# Introduction
+
+This page explains how to get the config files for using the T2 audio device, which allows use of the 3.5mm headphone port, the built in speakers, the built in mic and the headphones' mic.
+
+# Audio Configuration Files
+
+These files can be found [here](https://gist.github.com/MCMrARM/c357291e4e5c18894bea10665dcebffb), and there are instructions on where to put them in that gist.
+
+If you are using a 2019 16 inch MBP, use [this](https://gist.github.com/kevineinarsson/8e5e92664f97508277fefef1b8015fba) set of files, as that laptop has 6 speakers and needs slightly different config.
+
+# Using Pipewire instead of Pulseaudio
+
+You'll need to modify the `/lib/udev/rules.d/91-pulseaudio-custom.rules` file from the links above.
+
+```diff
+SUBSYSTEM!="sound", GOTO="pulseaudio_end"
+ACTION!="change", GOTO="pulseaudio_end"
+KERNEL!="card*", GOTO="pulseaudio_end"
+
+-SUBSYSTEMS=="pci", ATTRS{vendor}=="0x106b", ATTRS{device}=="0x1803", ENV{PULSE_PROFILE_SET}="apple-t2.conf"
++SUBSYSTEMS=="pci", ATTRS{vendor}=="0x106b", ATTRS{device}=="0x1803", ENV{PULSE_PROFILE_SET}="apple-t2.conf", ENV{ACP_PROFILE_SET}="apple-t2.conf"
+
+LABEL="pulseaudio_end"```
+
+# Issues
+
+- Some people are unable to get audio input to work. You may have to use a seperate microphone.
+- All of apple's fancy tuning of the speakers is done in macos, we don't have anything like that at the moment.

--- a/docs/guides/dkms.md
+++ b/docs/guides/dkms.md
@@ -2,6 +2,11 @@
 
 This page explains how to install the kernel modules for the Keyboard, Audio, Touchbar and the Ambient Light sensor with DKMS. You will need a patched kernel.
 
+# Do you need to do this?
+
+Is your keyboard working? If no, then you'll need the BCE module.
+If you have a Touchbar, is it working? If no, then you'll need the apple-ibridge module.
+
 # Installing modules
 
 1. Install the `dkms` package
@@ -20,17 +25,13 @@ sudo modprobe apple_ib_tb
 sudo modprobe apple_ib_als
 ```
 
-# Audio Configuration Files
-
-The Touchbar and keyboard should work.
-
-For audio, there are config files required, these can be found [here](https://gist.github.com/MCMrARM/c357291e4e5c18894bea10665dcebffb)
-
-If you are using a 2019 16 inch MBP, use [this](https://gist.github.com/kevineinarsson/8e5e92664f97508277fefef1b8015fba) set of files, as that laptop has 6 speakers.
+The Touchbar and keyboard should work, for audio, you'll need some config files, refer to the [Audio Config guide](https://wiki.t2linux.org/guides/audio-config).
 
 # Fixing Suspend
 
 Copy [this script](https://github.com/marcosfad/mbp-ubuntu/blob/master/files/suspend/rmmod_tb.sh) to `/lib/systemd/system-sleep/rmmod_tb.sh`
+
+It unloads the Touchbar modules as they can cause issues for suspend.
 
 # Issues
 

--- a/docs/guides/windows.md
+++ b/docs/guides/windows.md
@@ -1,7 +1,51 @@
 # Introduction
 
-This page is a guide on getting windows and Linux both installed.
+This page is a guide on getting Windows and Linux both installed. Secure Boot Must be disabled from macos recovery. If you want to be able to choose from macos, Windows, or Linux in the Startup Manager (the menu you get by holding ⌥ key), goto 'Using seperate EFI partitions'. If you just want to select between Linux and Windows in the GRUB bootloader, goto 'Using the same EFI partition'. 
 
+The simplist way to triple boot is to install windows first, and install linux on the same EFI partition, so that the Windows option in Startup Manager will let you pick Linux or Windows. To do that, follow the first set of instructions here.
+
+# Using the same EFI partition
+
+## If Windows is installed first
+
+1. Install linux normally, with a patched kernel and dkms modules (this is probably done for you if you are using an installer specific to t2 macs).
+2. Put your bootloader on `/dev/nvme0n1p1`, which should be set to mount at `/boot/efi`. Once it installs the bootloader, the windows entry in startup manager will boot linux.
+3. Fix blank screen issue that may occur when booting windows (Credits to gbrow004 for documenting this fix on his [Gist](https://gist.github.com/gbrow004/096f845c8fe8d03ef9009fbb87b781a4#fixing-bootcampwindows)).
+	1. Open a terminal and type in ``sudo gdisk /dev/nvme0n1``.
+	2. Press `x` for expert mode
+	3. Press `n` to create a protective MBR
+	4. Press `w` to write the partition and `y` to confirm
+	5. If gdisk doesn't quit, press `q` to exit the command
+4. Enable the GRUB menu so that you'll have time to pick windows
+	1. Boot into your linux install by selecting the windows option in startup manager.
+	2. Edit ``/etc/default/grub`` with any preferred editior (nano/vim/) and with sudo. Change line ``GRUB_TIMEOUT_STYLE`` to ``GRUB_TIMEOUT_STYLE=MENU``. If you are using `nano`, save the file by doing CTRL+X, Y, then enter.
+	3. We've now changed the GRUB Bootloader settings, but we now need to update GRUB to apply these changes. Type in ``sudo update-grub`` and hit enter. After the command is done, you're finished.
+5. You should now be able to boot either Windows or Linux from the GRUB bootloader.
+
+## If Linux is installed first
+
+1. Make sure that your linux partitions are not labled as `Microsoft Basic Data`, if they are, Bootcamp Assistant will think windows is already installed. To fix this, go to Linux and do `sudo cfdisk /dev/nvme0n1` and change the type of your linux partitions to `Linux Filesystem`.
+2. Install Windows normaly with Bootcamp. Windows will replace your Linux boot option.
+3. Boot into macos.
+4. `sudo diskutil mount disk0s1`
+5. Go to `/Volumes/EFI/efi`
+6. In this folder there will be a `Microsoft` folder, an `Apple` folder, one with your distro's name or just `GRUB`, and one called `Boot`. The `Boot` folder will have a file named `bootx64.efi`, rename this to `windows_bootx64.efi`
+7. Copy the `grubx64.efi` file in your distro's folder to `/Volumes/EFI/efi/Boot/bootx64.efi`. The the windows option in Startup Manager will now boot Linux.
+8. Fix blank screen issue that may occur when booting windows (Credits to gbrow004 for documenting this fix on his [Gist](https://gist.github.com/gbrow004/096f845c8fe8d03ef9009fbb87b781a4#fixing-bootcampwindows)).
+	1. In Linux, open a terminal and type in ``sudo gdisk /dev/nvme0n1``.
+	2. Press `x` for expert mode
+	3. Press `n` to create a protective MBR
+	4. Press `w` to write the partition and `y` to confirm
+	5. If gdisk doesn't quit, press `q` to exit the command
+9. Enable the GRUB menu so that you'll have time to pick windows
+	1. Boot into your linux install by selecting the windows option in startup manager.
+	2. Edit ``/etc/default/grub`` with any preferred editior (nano/vim/) and with sudo. Change line ``GRUB_TIMEOUT_STYLE`` to ``GRUB_TIMEOUT_STYLE=MENU``. If you are using `nano`, save the file by doing CTRL+X, Y, then enter.
+	3. We've now changed the GRUB Bootloader settings, but we now need to update GRUB to apply these changes. Type in ``sudo update-grub`` and hit enter. After the command is done, you're finished.
+10. You should now be able to boot either Windows or Linux from the GRUB bootloader.
+
+It may be possible to skip steps 5-8 by doing the following command in macos: `sudo sh -c "bless --mount /Volumes/EFI --setBoot --file /Volumes/EFI/efi/$(ls|grep -i -e microsoft -e boot -e apple -v)/grubx64.efi --shortform"` This might not prevent step 8 from being needed.
+
+# Using seperate EFI partitions
 
 ## Installing Linux (With or without Windows already installed)
 
@@ -39,13 +83,12 @@ If you are doing it manually:
 2. If your second EFI partition is labeled as `EFI System`, you'll need to use `cfdisk` again to make it not that, as the Windows installer fails if there are two.
 3. Bootcamp should install windows normally. If you put your Linux bootloader on `/dev/nvme0n1p1`, Windows will replace it, and that's why a second EFI partition is ideal.
 
-
-## Quality of life things
+# Quality of life things
 
 ### Giving Options in macOS Startup Manager Custom Icons
 
 Put an `icns` file with your desired icon in the top directory of the disk that the bootloader of the menu entry is on, and call it `.VolumeIcon.icns`.
 
-### Setting your Linux Partitions as `Linux Filesystem` type
+## Setting your Linux Partitions as `Linux Filesystem` type
 
 Use `sudo cfdisk /dev/nvme0n1` and change the type of your Linux partitions. This will show up when you do `diskutil list` in macOS.

--- a/docs/guides/windows.md
+++ b/docs/guides/windows.md
@@ -85,7 +85,7 @@ If you are doing it manually:
 
 # Quality of life things
 
-### Giving Options in macOS Startup Manager Custom Icons
+## Giving Options in macOS Startup Manager Custom Icons
 
 Put an `icns` file with your desired icon in the top directory of the disk that the bootloader of the menu entry is on, and call it `.VolumeIcon.icns`.
 

--- a/docs/guides/windows.md
+++ b/docs/guides/windows.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This page is a guide on getting Windows and Linux both installed. Secure Boot Must be disabled from macos recovery. If you want to be able to choose from macos, Windows, or Linux in the Startup Manager (the menu you get by holding ⌥ key), goto 'Using seperate EFI partitions'. If you just want to select between Linux and Windows in the GRUB bootloader, goto 'Using the same EFI partition'. 
+This page is a guide on getting Windows and Linux both installed. Secure Boot Must be disabled from macOS recovery. If you want to be able to choose from macOS, Windows, or Linux in the Startup Manager (the menu you get by holding ⌥ key), goto 'Using seperate EFI partitions'. If you just want to select between Linux and Windows in the GRUB bootloader, goto 'Using the same EFI partition'. 
 
 The simplist way to triple boot is to install windows first, and install linux on the same EFI partition, so that the Windows option in Startup Manager will let you pick Linux or Windows. To do that, follow the first set of instructions here.
 
@@ -26,7 +26,7 @@ The simplist way to triple boot is to install windows first, and install linux o
 
 1. Make sure that your linux partitions are not labled as `Microsoft Basic Data`, if they are, Bootcamp Assistant will think windows is already installed. To fix this, go to Linux and do `sudo cfdisk /dev/nvme0n1` and change the type of your linux partitions to `Linux Filesystem`.
 2. Install Windows normaly with Bootcamp. Windows will replace your Linux boot option.
-3. Boot into macos.
+3. Boot into macOS.
 4. `sudo diskutil mount disk0s1`
 5. Go to `/Volumes/EFI/efi`
 6. In this folder there will be a `Microsoft` folder, an `Apple` folder, one with your distro's name or just `GRUB`, and one called `Boot`. The `Boot` folder will have a file named `bootx64.efi`, rename this to `windows_bootx64.efi`
@@ -43,7 +43,7 @@ The simplist way to triple boot is to install windows first, and install linux o
 	3. We've now changed the GRUB Bootloader settings, but we now need to update GRUB to apply these changes. Type in ``sudo update-grub`` and hit enter. After the command is done, you're finished.
 10. You should now be able to boot either Windows or Linux from the GRUB bootloader.
 
-It may be possible to skip steps 5-8 by doing the following command in macos: `sudo sh -c "bless --mount /Volumes/EFI --setBoot --file /Volumes/EFI/efi/$(ls|grep -i -e microsoft -e boot -e apple -v)/grubx64.efi --shortform"` This might not prevent step 8 from being needed.
+It may be possible to skip steps 5-8 by doing the following command in macOS: `sudo sh -c "bless --mount /Volumes/EFI --setBoot --file /Volumes/EFI/efi/$(ls|grep -i -e microsoft -e boot -e apple -v)/grubx64.efi --shortform"` This might not prevent step 8 from being needed.
 
 # Using seperate EFI partitions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,8 @@ nav:
     - Guides:
           - Wifi: guides/wifi.md
           - DKMS: guides/dkms.md
-          - Windows Tripple Boot: guides/windows.md
+          - Windows Triple Boot: guides/windows.md
+          - Audio: guides/audio-config.md
     - Distributions:
           - Manjaro:
                 - Home: distributions/manjaro/home.md


### PR DESCRIPTION
Took the audio config section of the DKMS page out and put it in it's own page.
Added instructions on using the same EFI partition for both Linux and Windows to the triple boot page, and put links to it in the FAQ pages. ( issue #6 )
Realised that I can't spell.
