### PR TITLE
dkms: better permissions mode for rmmod script

### DIFF
--- a/docs/guides/dkms.md
+++ b/docs/guides/dkms.md
@@ -72,7 +72,7 @@ Copy [this script](https://github.com/marcosfad/mbp-ubuntu/blob/master/files/sus
 Now run :-
 
 ```sh
-sudo chmod a=rwx /lib/systemd/system-sleep/rmmod_tb.sh
+sudo chmod 755 /lib/systemd/system-sleep/rmmod_tb.sh
 sudo chown root:root /lib/systemd/system-sleep/rmmod_tb.sh
 ```
 


### PR DESCRIPTION
`chmod a=rwx` allows unprivileged users to append arbitrary code to that script, which will be run as root before and after suspend. Setting it to `755` only allows root to write to it and prevents this.