### PR TITLE
update known working firmware info for iMac20,1

### DIFF
--- a/docs/guides/wifi.md
+++ b/docs/guides/wifi.md
@@ -38,7 +38,7 @@ Please use the table below to check which patchsets will work for your model.
 | MacBookAir8,2    | BCM43?? | ?        | ?        | ?                    |
 | MacMini8,1       | BCM4364 | 3?       | Lanai    | Mojave / Big Sur     |
 | MacPro7,1        | BCM43?? | ?        | ?        | ?                    |
-| iMac20,1         | BCM43?? | ?        | ?        | ?                    |
+| iMac20,1         | BCM4364 | 4        | Hanauma  | Big Sur              |
 | iMac20,2         | BCM43?? | ?        | ?        | ?                    |
 | iMacPro1,1       | BCM43?? | ?        | ?        | ?                    |
 


### PR DESCRIPTION
```
[nihui@nihuini-LC2 ~]$ inxi -v 1
System:    Host: nihuini-LC2 Kernel: 5.12.11-300.mbp.fc33.x86_64 x86_64 bits: 64 Desktop: KDE Plasma 5.22.4 
           Distro: Fedora release 34 (Thirty Four) 
CPU:       Info: 10-Core Intel Core i9-10910 [MT MCP] speed: 800 MHz min/max: 800/5000 MHz 
Graphics:  Device-1: Advanced Micro Devices [AMD/ATI] Navi 14 [Radeon RX 5500/5500M / Pro 5500M] driver: amdgpu v: kernel 
           Device-2: Logitech HD Pro Webcam C920 type: USB driver: snd-usb-audio,uvcvideo 
           Display: x11 server: X.Org 1.20.11 driver: loaded: amdgpu,ati unloaded: fbdev,modesetting,radeon,vesa 
           resolution: 3840x2160~60Hz 
           OpenGL: renderer: AMD NAVI14 (DRM 3.40.0 5.12.11-300.mbp.fc33.x86_64 LLVM 12.0.0) v: 4.6 Mesa 21.1.5 
Drives:    Local Storage: total: 931.84 GiB used: 397.44 GiB (42.7%) 
Info:      Processes: 332 Uptime: 11m Memory: 31.2 GiB used: 2.38 GiB (7.6%) Shell: Bash inxi: 3.3.03 
```

```
[    3.450031] usbcore: registered new interface driver brcmfmac
[    3.450155] brcmfmac 0000:05:00.0: enabling device (0000 -> 0002)
[    3.552298] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac4364-pcie for chip BCM4364/4
[    4.371636] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac4364-pcie for chip BCM4364/4
[    4.389268] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM4364/4 wl0: Sep 11 2020 17:01:15 version 9.30.440.2.32.5.61 FWID 01-1d69e4b4
[    4.431642] brcmfmac 0000:05:00.0 wlp5s0: renamed from wlan0
```
