### PR TITLE
Changed link of Ubuntu repo to pre installation steps

### DIFF
--- a/docs/guides/wifi.md
+++ b/docs/guides/wifi.md
@@ -66,7 +66,7 @@ This older firmware is archived at [https://packages.aunali1.com/apple/wifi-fw/1
 
 The default kernels for **mbp-fedora** and **mbp-nixos** use Big Sur firmware.
 
-For **Ubuntu**, the "mbp-16x-wifi" variant kernels (use `sudo apt install linux-headers-5.10.52-mbp-16x-wifi linux-image-5.10.52-mbp-16x-wifi` to install, but change 5.10.52 to the kernel version you wish to install) uses Big Sur firmware too. Alternatively you can also get a Debian kernel (used by Ubuntu, Pop!_OS, Linux Mint etc.), from [this repo](https://github.com/AdityaGarg8/mbp-16.x-ubuntu-kernel/releases), as the repo may be updated faster with newer kernels. For **BCM4377** users the above repo is the only option for now.
+For **Ubuntu**, the "mbp-16x-wifi" variant kernels (use `sudo apt install linux-headers-5.10.52-mbp-16x-wifi linux-image-5.10.52-mbp-16x-wifi` to install, but change 5.10.52 to the kernel version you wish to install) uses Big Sur firmware too. Alternatively you can also get a Debian kernel (used by Ubuntu, Pop!_OS, Linux Mint etc.), from [this repo](https://github.com/AdityaGarg8/mbp-16.x-ubuntu-kernel#pre-installation-steps), as the repo may be updated faster with newer kernels. For **BCM4377** users the above repo is the only option for now.
 
 There are also kernels available for [Arch based distros](https://github.com/Redecorating/mbp-16.1-linux-wifi/releases) (like Arch Linux and Manjaro) but you can [compile it yourself](https://wiki.t2linux.org/guides/wifi/#compiling-with-corelliums-patchset) if you need/want to.
 


### PR DESCRIPTION
People generally ignore the DKMS guide and then face issues with new kernels. So I have changed the link and the new link shall go the the Installation instructions instead of releases page of my repo. Over there the warning for DKMS is written and the link for releases is also mentioned.