### PR TITLE
wifi: add imac19,x to table, guess remaining islands

### DIFF
--- a/docs/guides/wifi.md
+++ b/docs/guides/wifi.md
@@ -34,10 +34,14 @@ Please use the table below to check which patchsets will work for your model.
 | MacBookAir8,1    | BCM4355 | ?        | Hawaii   | Mojave               |
 | MacBookAir8,2    | BCM4355 | 0c       | Hawaii   | Mojave               |
 | MacMini8,1       | BCM4364 | 3        | Lanai    | Mojave / Big Sur     |
-| MacPro7,1        | BCM4364 | ?        | ?        | ?                    |
+| MacPro7,1        | BCM4364 | ?        | Borneo?  | Big Sur?             |
 | iMac20,1         | BCM4364 | 4        | Hanauma  | Big Sur              |
 | iMac20,2         | BCM4364 | 4        | Kure     | Big Sur              |
-| iMacPro1,1       | BCM4364 | ?        | Ekans?   | ?                    |
+| iMac19,1*        | BCM4364 | 3?       | Nihau    | Mojave / Big Sur     |
+| iMac19,2*        | BCM4364?| 3?       | Midway?  | Mojave / Big Sur?    |
+| iMacPro1,1       | BCM4364 | ?        | Ekans?   | Mojave / Big Sur?    |
+
+\*iMac19,x don't have the T2 chip, but they have the same type of wifi chip as T2 Macs.
 
 *If there is missing/uncertain information for your model, please open a [pull request](https://github.com/t2linux/wiki/edit/master/docs/guides/wifi.md) or [issue](https://github.com/t2linux/wiki/issues/new) or mention it on the [discord](https://discord.com/invite/68MRhQu).*
 


### PR DESCRIPTION
iMac19,1 has BCM4364 but no T2

Link: https://github.com/Dunedan/mbp-2016-linux/issues/112#issuecomment-674389977

Link: https://support.apple.com/en-us/HT208862

Link: https://support.apple.com/en-us/HT201634

With most islands known, I've made guesses based off which macos version models released with and their bluetooth chip names. If my guesses are correct (or just have a couple of models switched), the only ones left are Sid and Kahana. These two islands are the only ones in both the 4364B2 and 4364B3 folders, and the only ones in the Mojave version of the 4364B3 folder. Could be the two models missing here https://www.theiphonewiki.com/wiki/T8012#Enabled_Mac_Products