### PR TITLE
remove backlash pasted from previous bash command

### DIFF
--- a/docs/distributions/arch/installation.md
+++ b/docs/distributions/arch/installation.md
@@ -56,7 +56,7 @@ You will need:
 
    ```ini
    [mbp]
-   Server = https://dl.t2linux.org/archlinux/\$repo/\$arch
+   Server = https://dl.t2linux.org/archlinux/$repo/$arch
    ```
 
 10. Install a bootloader, probably Grub, but you can also use systemd-boot. Don't do both.


### PR DESCRIPTION
https://github.com/t2linux/wiki/commit/b2274b147343aa260d6515f95b25c0b9c4c54300#r61006493

no backslashes before `$` [doc](https://archlinux.org/pacman/pacman.conf.5.html)