### PR TITLE
Add new ISO with bugs fixed

### DIFF
--- a/docs/distributions/ubuntu/installation.md
+++ b/docs/distributions/ubuntu/installation.md
@@ -2,7 +2,7 @@
 
 Warning: Mac Mini users will need to [install rEFInd](https://wiki.t2linux.org/guides/refind/) to boot GRUB as the Mac Startup Manager on Mac Mini is not booting Ubuntu's GRUB directly.
 
-[Download here](https://github.com/marcosfad/mbp-ubuntu/releases/tag/v20.04-5.7.19-1)
+[Download here](https://github.com/AdityaGarg8/mbp-ubuntu/releases/tag/v20.04-5.15.14)
 
 The iso you should download depends on your machine, but usually the normal mbp iso works fine.
 

--- a/docs/distributions/ubuntu/installation.md
+++ b/docs/distributions/ubuntu/installation.md
@@ -2,7 +2,7 @@
 
 Warning: Mac Mini users will need to [install rEFInd](https://wiki.t2linux.org/guides/refind/) to boot GRUB as the Mac Startup Manager on Mac Mini is not booting Ubuntu's GRUB directly.
 
-[Download here](https://github.com/AdityaGarg8/mbp-ubuntu/releases/tag/v20.04-5.15.14)
+[Download here](https://github.com/AdityaGarg8/mbp-ubuntu/releases/latest)
 
 The iso you should download depends on your machine, but usually the normal mbp iso works fine.
 

--- a/docs/guides/wifi.md
+++ b/docs/guides/wifi.md
@@ -5,9 +5,6 @@ This page is a step by step guide to get wifi working on T2 Macs.
 !!! Info "Fedora"
     Fedora users are requested to follow the older version of this guide [here](https://github.com/t2linux/wiki/blob/a4b46a7cfbe7efcbb6a0b6111e22172b0f5c4a77/docs/guides/wifi.md).
 
-!!! Info "Ubuntu"
-    Ubuntu users have to upgrade their kernel first by following the instructions [here](https://github.com/AdityaGarg8/T2-Ubuntu-Kernel#pre-installation-steps).
-
 ## Getting the firmware
 
 In order to get wifi running on Linux, we need to get the firmware from macOS and copy it to Linux with appropriate changes. Thanks to Asahi Linux, who has made the process much simpler. You may follow the steps below to get the firmware and copy it to Linux properly.


### PR DESCRIPTION
The reason for failures on the previous ISO probably was the old kernel config (way back from 5.6). I've recompiled 5.15.14 using official kernel config for 5.15 from Ubuntu Jammy Jellyfish fork and now users seem to be getting success