### PR TITLE
Remove instruction to upgrade DKMS drivers.

### DIFF
--- a/docs/guides/wifi.md
+++ b/docs/guides/wifi.md
@@ -6,7 +6,7 @@ This page is a step by step guide to get wifi working on T2 Macs.
     Fedora users are requested to follow the older version of this guide [here](https://github.com/t2linux/wiki/blob/a4b46a7cfbe7efcbb6a0b6111e22172b0f5c4a77/docs/guides/wifi.md).
 
 !!! Info "Ubuntu"
-    If you have used the [old but stable](https://github.com/marcosfad/mbp-ubuntu/releases/tag/v20.04-5.7.19-1) ISO, then you will have to upgrade your [DKMS drivers](https://wiki.t2linux.org/guides/dkms/) and your [kernel](https://github.com/AdityaGarg8/T2-Ubuntu-Kernel#pre-installation-steps) before following this guide.
+    If you have used the [old but stable](https://github.com/marcosfad/mbp-ubuntu/releases/tag/v20.04-5.7.19-1) ISO, then you will have to upgrade your [kernel](https://github.com/AdityaGarg8/T2-Ubuntu-Kernel#pre-installation-steps) before following this guide.
 
 ## Getting the firmware
 


### PR DESCRIPTION
Now, Ubuntu kernels shall be having the DKMS modules built-in