### PR TITLE
Update audio-config.md

### DIFF
--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -15,13 +15,8 @@ If not present, you'll have to update your bootup kernel params:
 - Reboot and ensure `cat /proc/cmdline` contains those params
 
 
----
-
-**Note for systemd-boot users**
-
-You'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pcie_ports=compat` to the options line.
-
-The files to edit will have the ".conf" extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
+!!!note "systemd-boot"
+    If you use systemd-boot you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pcie_ports=compat` to the options line. The files to edit will have the `.conf` extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
 
 ---
 

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -4,6 +4,16 @@ This page explains how to get the config files for using the T2 audio device, wh
 
 Before you proceed, make sure you already have `apple_bce` loaded by running `lsmod | grep apple_bce`. If not, follow the instructions on [how to setup the BCE module](https://wiki.t2linux.org/guides/dkms/#installing-modules).
 
+# Enable Pass-Through Kernel Parameters
+
+Cat `cat /proc/cmdline` and ensure that your kernel parameters contain `intel_iommu=on iommu=pt`.
+
+If not present:
+
+- edit `/etc/default/grub` and update `GRUB_CMDLINE_LINUX` to include them
+- Apply your edits by running `sudo update-grub` on ubuntu or `grub-mkconfig -o /boot/grub/grub.cfg` for other distros
+- Reboot and ensure `cat /proc/cmdline` contains those params
+
 # Audio Configuration Files
 
 In most scenarios, you should use [these files](https://gist.github.com/MCMrARM/c357291e4e5c18894bea10665dcebffb), following the instructions in that gist's `README.md`.

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -6,13 +6,16 @@ Before you proceed, make sure you already have `apple_bce` loaded by running `l
 
 # Enable Pass-Through Kernel Parameters
 
-Cat `cat /proc/cmdline` and ensure that your kernel parameters contain `intel_iommu=on iommu=pt`.
+Cat `cat /proc/cmdline` and ensure that your kernel parameters contain `intel_iommu=on iommu=pt pcie_ports=compat`.
 
-If not present:
+If not present, you'll have to update your bootup kernel params:
 
-- edit `/etc/default/grub` and update `GRUB_CMDLINE_LINUX` to include them
+- edit `/etc/default/grub` and update `GRUB_CMDLINE_LINUX` to include `intel_iommu=on iommu=pt pcie_ports=compat`
 - Apply your edits by running `sudo update-grub` on ubuntu or `grub-mkconfig -o /boot/grub/grub.cfg` for other distros
 - Reboot and ensure `cat /proc/cmdline` contains those params
+
+NOTE: if you use systemd-boot, you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pcie_ports=compat` to the options line.
+- The location of these conf files can vary by distro. Arch stores them in `/boot/efi/loader/entries/arch.conf` and `/boot/efi/loader/entries/arch-fallback.conf`
 
 # Audio Configuration Files
 

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -14,8 +14,16 @@ If not present, you'll have to update your bootup kernel params:
 - Apply your edits by running `sudo update-grub` on ubuntu or `grub-mkconfig -o /boot/grub/grub.cfg` for other distros
 - Reboot and ensure `cat /proc/cmdline` contains those params
 
-NOTE: if you use systemd-boot, you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pcie_ports=compat` to the options line.
-- The location of these conf files can vary by distro. Arch stores them in `/boot/efi/loader/entries/arch.conf` and `/boot/efi/loader/entries/arch-fallback.conf`
+
+---
+
+**Note for systemd-boot users**
+
+You'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pcie_ports=compat` to the options line.
+
+The files to edit will have the ".conf" extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
+
+---
 
 # Audio Configuration Files
 

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -14,11 +14,8 @@ If not present, you'll have to update your bootup kernel params:
 - Apply your edits by running `sudo update-grub` on ubuntu or `grub-mkconfig -o /boot/grub/grub.cfg` for other distros
 - Reboot and ensure `cat /proc/cmdline` contains those params
 
-
 !!!note "systemd-boot"
     If you use systemd-boot you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pcie_ports=compat` to the options line. The files to edit will have the `.conf` extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
-
----
 
 # Audio Configuration Files
 


### PR DESCRIPTION
Add instructions to ensure pass-through kernel params are present. Audio gists crash without pass-through mode enabled.