### PR TITLE
Fix sleep and resume on Arch Linux

### DIFF
--- a/docs/tools/rmmod_tb.sh
+++ b/docs/tools/rmmod_tb.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 if [ "${1}" = "pre" ]; then
         modprobe -r apple_ib_tb
+        modprobe -r hid_apple
 elif [ "${1}" = "post" ]; then
+        modprobe hid_apple
         modprobe apple_ib_tb
 fi


### PR DESCRIPTION
This fixes sleep/resume on Arch Linux, otherwise the keyboard and touchbar fail to wake up properly.

I'm not entirely sure why this works, but without adding the lines for `hid_apple`, the touchbar is permenantly black and the keyboard fails to wake up from sleep. I got this idea from someone on Discord who found this was identical to the script in the Fedora image, so I gave it a try and it worked perfectly (apart from the known issue with the keyboard backlight).