### PR TITLE
Added a systemd service to monitor and keep mic volume at 400% on mbp16.1 2019

### DIFF
--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -55,6 +55,7 @@ Note: The updated locations for the files in the links above for Pipewire distri
 # Approaches to fixing low microphone volume
 
 ## Pulseaudio (2019 16" MacBook Pro)
+
 [Monitor](https://github.com/mahboobkarimian/mbp-2019-Ubuntu-audio) the volume of the microphone and set it back to 400% when a sudden drop in the volume of the microphone occurs (something sets in to 100%. This will help to have consistent microphone volume during video/audio calls.
 
 ## KDE

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -54,6 +54,9 @@ Note: The updated locations for the files in the links above for Pipewire distri
 
 # Approaches to fixing low microphone volume
 
+## Pulseaudio (2019 16" MacBook Pro)
+[Monitor](https://github.com/mahboobkarimian/mbp-2019-Ubuntu-audio) the volume of the microphone and set it back to 400% when a sudden drop in the volume of the microphone occurs (something sets in to 100%. This will help to have consistent microphone volume during video/audio calls.
+
 ## KDE
 
 The "Audio Volume" dialog / Audio in System Settings allow users to "Raise maximum volume", allowing to go past 100%. This


### PR DESCRIPTION
If you are using pulseaudio and you can't replace it with pipewire to use its solutions to maintain the volume of the microphone on your Mac, or you use gnome and you can't use the volume increase available in KDE, this script and a systemd service will help you to always maintain your mic volume at 400%. This script is for MacBook Pro 16" 2019, but with a little effort, it can be ported to other Macs who are suffering from low microphone volume or sudden drops during online video/audio calls.
The script continuously checks for mic volume changes using `pactl subscribe` and sets it to 400% when there is a change.