### PR TITLE
docs/distributions/nixos: update networking instructions

### DIFF
--- a/docs/distributions/nixos/installation.md
+++ b/docs/distributions/nixos/installation.md
@@ -12,7 +12,7 @@
 4. Reboot while pressing the `Option` key and select the orange `EFI Boot` option.
 5. Partition your disk using `cfdisk` or the tool of your preference, initialize the partitions with the `mkfs` command of the filesystem you want (`mkswap` is for swap) and mount them under `/mnt`.
     * **Note**: You might want to leave a little part of your disk as a FAT32 partition to be able to transfer files easily between MacOS and Linux.
-6. Connect to internet using `iwctl`.
+6. Run `systemctl start wpa_supplicant` and connect to internet using `wpa_cli`.
 7. Generate your configuration using `sudo nixos-generate-config --root /mnt`.
 8. Edit `/mnt/etc/configuration.nix` to your liking. Add `"${builtins.fetchGit { url = "https://github.com/kekrby/nixos-hardware.git"; }}/apple/t2"` to `imports`.
     * **Note**: Don't forget to add a bootloader, `systemd-boot` works quite well. If you want to use `GRUB`, don't forget to set `boot.grub.efiInstallAsRemovable`, `boot.grub.efiSupport` to `true` and `boot.grub.device` to `"nodev"`.


### PR DESCRIPTION
`wpa_supplicant` seems to work better than `iwd`. I listed some of the problems I encountered at https://github.com/kekrby/nixos-hardware/commit/8a8b616ad0755a61317ab85dd48a8001d8a44861.