### PR TITLE
Audio Config: Add tips for the platforms with GRUB2 installed.

### DIFF
--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -12,6 +12,7 @@ If not present, you'll have to update your bootup kernel params:
 
 - edit `/etc/default/grub` and update `GRUB_CMDLINE_LINUX` to include `intel_iommu=on iommu=pt pcie_ports=compat`
 - Apply your edits by running `sudo update-grub` on ubuntu or `sudo grub-mkconfig -o /boot/grub/grub.cfg` for other distros
+  - *Note* that, on the platforms where `grub`'s version is 2.x, these commands should be instead `sudo update-grub2` or `sudo grub2-mkconfig -o /boot/grub2/grub.cfg`, `grub`'s version can be checked by running `sudo grub2-install --version`
 - Reboot and ensure `cat /proc/cmdline` contains those params
 
 !!!note "systemd-boot"


### PR DESCRIPTION
Some platforms have shipped with GRUB 2.x instead of GRUB 1.x(e.g., Fedora 36), and the command line interfaces for 2.x are slightly different from that of 1.x thus it might be appropriate to add more descriptions here.

Tested on: Fedora36, MBP2019.

Anyway, really appreciate that you guys make my laptop usable, thanks!