### PR TITLE
docs/roadmap: remove mention of setting the audio model from the NixOS section

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ Ubuntu also has a graphical installer. Additionally, less post configuration wor
 Fedora also has a prebuilt ISO and a graphical installer. Most things work out of the box, though audio and WiFi generally need to be set up as in the guides below. Then they should work flawlessly.
 
 NixOS has both prebuilt graphical and command line installers. Support for T2 devices is provided in the form of a `nixos-hardware` module.
-Importing the module and setting the audio model are the only things you have to do to get your configuration working on your Mac.
+Importing the module is the only thing you have to do to get your configuration working on your Mac.
 
 If you wish to use another distribution, you can install it normally, also follow the steps to [install the kernel yourself manually](https://wiki.t2linux.org/guides/kernel/) and follow the [post installation steps](https://wiki.t2linux.org/roadmap/#configuring-the-installation).
 


### PR DESCRIPTION
It is not required anymore.