### PR TITLE
Tools: Update wifi script to support iMac19,1 and iMac 19,2

### DIFF
--- a/docs/guides/wifi-bluetooth.md
+++ b/docs/guides/wifi-bluetooth.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs.
+This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs. This guide is also applicable to **iMac19,1** and **iMac19,2**, which are non T2 Intel Macs and the newer Apple Silicon Macs. Although, Wi-Fi should have been set up already in case of Apple Silicon Macs by Asahi's installer.
 
 ## Ensure Kernel Supports OTP Firmware Selection
 

--- a/docs/guides/wifi-bluetooth.md
+++ b/docs/guides/wifi-bluetooth.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs. This guide is also applicable to **iMac19,1** and **iMac19,2**, which are non T2 Intel Macs and the newer Apple Silicon Macs. Although, Wi-Fi should have been set up already in case of Apple Silicon Macs by Asahi's installer.
+This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs. This guide is also applicable to **iMac19,1** and **iMac19,2**, which are non T2 Intel Macs, and the newer **Apple Silicon Macs**. Although, Wi-Fi should have been set up already in case of **Apple Silicon Macs** by Asahi's installer.
 
 ## Ensure Kernel Supports OTP Firmware Selection
 

--- a/docs/tools/firmware.sh
+++ b/docs/tools/firmware.sh
@@ -18,6 +18,7 @@ case "$os" in
 			echo -e "\nThis script is compatible only with macOS Monterey or later. Please upgrade your macOS."
 			exit 1
 		fi
+		identifier=$(system_profiler SPHardwareDataType | grep "Model Identifier" | cut -d ":" -f 2 | xargs)
 		echo "Mounting the EFI partition"
 		sudo diskutil mount disk0s1
 		echo "Getting Wi-Fi and Bluetooth firmware"
@@ -27,6 +28,19 @@ case "$os" in
 			tar czvf /Volumes/EFI/firmware.tar.gz *
 		else
 			tar czf /Volumes/EFI/firmware.tar.gz *
+		fi
+		if [[ (${identifier} = iMac19,1) || (${identifier} = iMac19,2) ]]
+		then
+			nvramfile=$(ioreg -l | grep RequestedFiles | cut -d "/" -f 5 | rev | cut -c 4- | rev)
+			txcapblob=$(ioreg -l | grep RequestedFiles | cut -d "/" -f 3 | cut -d "\"" -f 1)
+			if [[ ${1-default} = -v ]]
+			then
+				cp -v /usr/share/firmware/wifi/C-4364__s-B2/${nvramfile} /Volumes/EFI/brcmfmac4364b2-pcie.txt
+				cp -v /usr/share/firmware/wifi/C-4364__s-B2/${txcapblob} /Volumes/EFI/brcmfmac4364b2-pcie.txcap_blob
+			else
+				cp /usr/share/firmware/wifi/C-4364__s-B2/${nvramfile} /Volumes/EFI/brcmfmac4364b2-pcie.txt
+				cp /usr/share/firmware/wifi/C-4364__s-B2/${txcapblob} /Volumes/EFI/brcmfmac4364b2-pcie.txcap_blob
+			fi
 		fi
 		echo "Copying this script to EFI"
 		cd - >/dev/null
@@ -73,6 +87,19 @@ case "$os" in
 		else
 			sudo tar xf /tmp/apple-wifi-fw/firmware.tar
 		fi
+		for file in "$mountpoint/brcmfmac4364b2-pcie.txt" \
+		            "$mountpoint/brcmfmac4364b2-pcie.txcap_blob"
+		do
+			if [ -f "$file" ]
+			then
+				if [[ ${1-default} = -v ]]
+				then
+					sudo cp -v $file /lib/firmware/brcm
+				else
+					sudo cp $file /lib/firmware/brcm
+				fi
+			fi
+		done
 		sudo modprobe -r brcmfmac
 		sudo modprobe brcmfmac
 		sudo modprobe -r hci_bcm4377
@@ -84,7 +111,16 @@ case "$os" in
 		if [[ ($input != y) && ($input != Y) ]]
 		then
 			echo "Removing the copy from the EFI partition"
-			sudo rm $mountpoint/firmware.tar.gz $mountpoint/firmware.sh
+			for file in "$mountpoint/brcmfmac4364b2-pcie.txt" \
+			            "$mountpoint/brcmfmac4364b2-pcie.txcap_blob" \
+			            "$mountpoint/firmware.tar.gz" \
+			            "$mountpoint/firmware.sh"
+			do
+				if [ -f "$file" ]
+				then
+					sudo rm $file
+				fi
+			done
 		fi
 		echo "Running post-installation scripts"
 		exec sudo sh -c "umount /dev/nvme0n1p1 && mount -a && rmdir /tmp/apple-wifi-efi && echo Done!"


### PR DESCRIPTION
The brcmfmac driver is unable to read OTP info in these non T2 Macs, for the NVRAM and txcap_blob files. Let the script do it for them.