### PR TITLE
Update fedora ISO url to point at new repo

### DIFF
--- a/docs/distributions/fedora/installation.md
+++ b/docs/distributions/fedora/installation.md
@@ -2,7 +2,7 @@
 
 Many thanks to Mike for building. You can download a live iso from Mikeeq [here](https://github.com/mikeeq/mbp-fedora).
 
-If you need a more updated kernel, use the iso from [sharpenedblade](https://github.com/sharpenedblade/t2linux-fedora-iso/releases). Remember to follow the [Wi-Fi guide](https://wiki.t2linux.org/guides/wifi-bluetooth/).
+If you need a more updated kernel, use the iso from [sharpenedblade](https://github.com/t2linux-fedora/t2linux-fedora-iso/releases). Remember to follow the [Wi-Fi guide](https://wiki.t2linux.org/guides/wifi-bluetooth/).
 
 # Hardware Requirements
 

--- a/docs/distributions/fedora/installation.md
+++ b/docs/distributions/fedora/installation.md
@@ -2,7 +2,7 @@
 
 Many thanks to Mike for building. You can download a live iso from Mikeeq [here](https://github.com/mikeeq/mbp-fedora).
 
-If you need a more updated kernel, use the iso from [sharpenedblade](https://github.com/t2linux-fedora/t2linux-fedora-iso/releases). Remember to follow the [Wi-Fi guide](https://wiki.t2linux.org/guides/wifi-bluetooth/).
+If you need a more updated kernel, use the iso from [sharpenedblade](https://github.com/t2linux/t2linux-fedora-iso/releases). Remember to follow the [Wi-Fi guide](https://wiki.t2linux.org/guides/wifi-bluetooth/).
 
 # Hardware Requirements
 


### PR DESCRIPTION
I moved my kernel and ISO repos to the `t2linux-fedora` org, so this updates the link in the wiki page.