### PR TITLE
Add t2linux/t2linux-fedora-kernel link to guides

### DIFF
--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -23,6 +23,7 @@ Many distro maintainers provide compiled kernels which can be installed on your 
 | Arch based distros                  | <https://github.com/Redecorating/linux-t2-arch> |
 | Arch based distros (Xanmod kernels) | <https://github.com/NoaHimesaka1873/linux-xanmod-edge-t2> |
 | Fedora                              | <https://github.com/mikeeq/mbp-fedora-kernel> |
+| Fedora                              | <https://github.com/t2linux/t2linux-fedora-kernel> |
 | Gentoo                              | <https://github.com/t2linux/T2-Gentoo-Kernel> |
 | Manjaro                             | <https://github.com/NoaHimesaka1873/manjaro-kernel-t2> |
 | NixOS                               | <https://github.com/kekrby/nixos-hardware> |

--- a/docs/guides/preinstall.md
+++ b/docs/guides/preinstall.md
@@ -20,7 +20,8 @@ If there is an ISO with T2 support for your distro, you can download it here:
 | Arch Linux         | <https://github.com/t2linux/archiso-t2/releases/latest> |
 | blendOS            | <https://blendos.co/#t2linux> |
 | EndeavourOS        | <https://github.com/t2linux/EndeavourOS-ISO-t2/releases/latest> |
-| Fedora Linux       | <https://github.com/mikeeq/mbp-fedora> |
+| Fedora       | <https://github.com/mikeeq/mbp-fedora> |
+| Fedora       | <https://github.com/t2linux/t2linux-fedora-iso/releases latest> |
 | Gentoo             | Please refer to this [page](https://wiki.t2linux.org/distributions/gentoo/installation/) |
 | Manjaro            | <https://github.com/NoaHimesaka1873/manjaroiso-t2/releases/latest> |
 | NixOS              | <https://github.com/t2linux/nixos-t2-iso> |

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ If the distribution you want to use has a guide [here](https://wiki.t2linux.org/
 - Arch [https://github.com/t2linux/archiso-t2](https://github.com/t2linux/archiso-t2)
 - EndeavourOS [https://github.com/t2linux/EndeavourOS-ISO-t2](https://github.com/t2linux/EndeavourOS-ISO-t2)
 - Fedora [https://github.com/mikeeq/mbp-fedora](https://github.com/mikeeq/mbp-fedora)
+- Fedora [https://github.com/t2linux/t2linux-fedora-iso](https://github.com/t2linux/t2linux-fedora-iso)
 - Gentoo [https://github.com/t2linux/T2-Gentoo-Kernel](https://github.com/t2linux/T2-Gentoo-Kernel)
 - Manjaro [https://github.com/NoaHimesaka1873/manjaroiso-t2](https://github.com/NoaHimesaka1873/manjaroiso-t2)
 - Tails [https://github.com/T2minator/mbp-tails](https://github.com/T2minator/mbp-tails)


### PR DESCRIPTION
Adds downloads for t2linux-fedora kernel and ISO to the list of download links. This also changes "Fedora Linux" to just "Fedora"