### PR TITLE
Update installation.md to init keyring

### DIFF
--- a/docs/distributions/arch/installation.md
+++ b/docs/distributions/arch/installation.md
@@ -22,7 +22,7 @@ You will need:
 
     -    Using pacstrap (more vanilla Arch experience)
 
-         1. Run `pacstrap /mnt base linux-t2 apple-t2-audio-config apple-bcm-firmware linux-firmware iwd grub efibootmgr tiny-dfr t2fand` (omit the `grub efibootmgr` packages from this if you intend to use systemd-boot as your bootloader). You can choose to use Xanmod kernel instead. In this case, replace `linux-t2` with `linux-xanmod-t2`.
+         1. Run `pacstrap -K /mnt base linux-t2 apple-t2-audio-config apple-bcm-firmware linux-firmware iwd grub efibootmgr tiny-dfr t2fand` (omit the `grub efibootmgr` packages from this if you intend to use systemd-boot as your bootloader). You can choose to use Xanmod kernel instead. In this case, replace `linux-t2` with `linux-xanmod-t2`.
 
          2. Add repository to `/mnt/etc/pacman.conf`, by adding this:
 


### PR DESCRIPTION
We need to initialize the keyring to be able to install in new root. Both `pacstrap` and `t2strap` failed due to this issue. However, I did not test whether `t2strap` would succeed or not with `-K` flag so I didn't add it to the fix.