### PR TITLE
Update postinstall.md for LUKS on EndeavourOS

### DIFF
--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -83,6 +83,16 @@ The steps to be followed vary depending upon the initramfs module loading mechan
          ```
 
     3. Run `sudo mkinitcpio -P`.
+ 
+- On EndeavourOS, which uses `dracut`
+
+    1. Create and edit a file at `/etc/dracut.conf.d/myflags.conf`, using e.g. `sudo vim /etc/dracut.conf.d/myflags.conf`
+  
+    2. Add the following line:
+
+         `force_drivers+=" apple-bce "`
+       
+    3. Run `sudo dracut --force` to regenerate the initramfs with this change
 
 - On systems with other initramfs/initrd generation systems:
 


### PR DESCRIPTION
Added a bullet point to the 'Making modules load on early boot' section to share the method I used to make the apple-bce module load early on EndeavourOS (which uses dracut, not mkinitcpio) so that the hard drive encryption password can be entered on the Apple keyboard.