### PR TITLE
Added suspension workaround script to postinstall.md

### DIFF
--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -141,3 +141,37 @@ blacklist cdc_mbim" >> /etc/modprobe.d/blacklist.conf'
 ```
 
 Please note that this internal ethernet interface is required for various services including touchid that there currently is no Linux support for. In the future, if any of these services are supported, you'll need to undo this.
+
+# Suspension Workaround
+
+S3 suspension has been broken since macOS Sonoma, it has never been fixed, but this workaround will make deep suspension work:
+
+1. Create and edit this file: `/etc/systemd/system/suspend-fix-t2.service`
+2. Paste this content:
+```service
+[Unit]
+Description=Disable and Re-Enable Apple BCE Module (and Wi-Fi)
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+User=root
+Type=oneshot
+RemainAfterExit=yes
+
+ExecStart=/usr/bin/modprobe -r brcmfmac_wcc
+ExecStart=/usr/bin/modprobe -r brcmfmac
+ExecStart=/usr/bin/rmmod -f apple-bce
+
+ExecStop=/usr/bin/modprobe apple-bce
+ExecStart=/usr/bin/modprobe brcmfmac
+ExecStart=/usr/bin/modprobe brcmfmac_wcc
+
+[Install]
+WantedBy=sleep.target
+```
+3. Enable the service: `sudo systemctl enable --now suspend-fix-t2.service`
+
+NOTE:  
+This seems to be working only on Arch with `CONFIG_MODULE_FORCE_UNLOAD=y` in the kernel config.  
+To check: `zcat /proc/config.gz | grep "CONFIG_MODULE_FORCE_UNLOAD"`


### PR DESCRIPTION
As discussed on discord this script will enable user with macOS Sonoma to perform a full sleep/wake in S3 mode.