### PR TITLE
Add json metadata for the ISO and distro list

### DIFF
--- a/docs/tools/distro-metadata.json
+++ b/docs/tools/distro-metadata.json
@@ -22,31 +22,31 @@
       "iso": ["https://github.com/t2linux/fedora-iso/releases/download/f40.0/t2linux-fedora-live-sway-40.iso"]
     },
     {
-      "name": "Ubuntu (Jammy)",
+      "name": "Ubuntu 22.04 - Jammy Jellyfish",
       "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-22.04-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-22.04-6.9.5-t2-jammy.iso.00"]
     },
     {
-      "name": "Ubuntu (Noble)",
+      "name": "Ubuntu 24.04 - Noble Numbat",
       "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-24.04-6.9.5-t2-noble.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-24.04-6.9.5-t2-noble.iso.01"]
     },
     {
-      "name": "Kubuntu (Jammy)",
+      "name": "Kubuntu 22.04 - Jammy Jellyfish",
       "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-22.04-6.9.5-t2-jammy.iso.00","https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-22.04-6.9.5-t2-jammy.iso.01"]
     },
     {
-      "name": "Kubuntu (Noble)",
+      "name": "Kubuntu 24.04 - Noble Numbat",
       "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-24.04-6.9.5-t2-noble.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-24.04-6.9.5-t2-noble.iso.01"]
     },
     {
-      "name": "Linux Mint Cinnamon",
+      "name": "Linux Mint - Cinnamon",
       "iso": ["https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-cinnamon-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-cinnamon-6.9.5-t2-jammy.iso.01"]
     },
     {
-      "name": "Linux Mint Mate",
+      "name": "Linux Mint - Mate",
       "iso": ["https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-mate-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-mate-6.9.5-t2-jammy.iso.01"]
     },
     {
-      "name": "Linux Mint XFCE",
+      "name": "Linux Mint - XFCE",
       "iso": ["https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-xfce-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-xfce-6.9.5-t2-jammy.iso.01"]
     },
     {

--- a/docs/tools/distro-metadata.json
+++ b/docs/tools/distro-metadata.json
@@ -1,0 +1,61 @@
+{
+  "all": [
+    {
+      "name": "Arch Linux",
+      "iso": ["https://github.com/t2linux/archiso-t2/releases/download/2024.04.09/archlinux-t2-2024.04.09-t2-x86_64.iso"]
+    },
+    {
+      "name": "EndeavourOS",
+      "iso": ["https://nightly.link/t2linux/EndeavourOS-ISO-t2/actions/runs/8866649470/built-iso.zip"],
+      "iso_compression": "zip"
+    },
+    {
+      "name": "Fedora Workstation",
+      "iso": ["https://github.com/t2linux/fedora-iso/releases/download/f40.0/t2linux-fedora-live-workstation-40.iso"]
+    },
+    {
+      "name": "Fedora KDE",
+      "iso": ["https://github.com/t2linux/fedora-iso/releases/download/f40.0/t2linux-fedora-live-kde-40.iso.00", "https://github.com/t2linux/fedora-iso/releases/download/f40.0/t2linux-fedora-live-kde-40.iso.01"]
+    },
+    {
+      "name": "Fedora Sway",
+      "iso": ["https://github.com/t2linux/fedora-iso/releases/download/f40.0/t2linux-fedora-live-sway-40.iso"]
+    },
+    {
+      "name": "Kubuntu (Jammy)",
+      "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-22.04-6.9.5-t2-jammy.iso.00","https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-22.04-6.9.5-t2-jammy.iso.01"]
+    },
+    {
+      "name": "Kubuntu (Noble)",
+      "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-24.04-6.9.5-t2-noble.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-24.04-6.9.5-t2-noble.iso.01"]
+    },
+    {
+      "name": "Linux Mint Cinnamon",
+      "iso": ["https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-cinnamon-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-cinnamon-6.9.5-t2-jammy.iso.01"]
+    },
+    {
+      "name": "Linux Mint Mate",
+      "iso": ["https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-mate-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-mate-6.9.5-t2-jammy.iso.01"]
+    },
+    {
+      "name": "Linux Mint XFCE",
+      "iso": ["https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-xfce-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Mint/releases/download/v6.9.5-1/linuxmint-21.3-xfce-6.9.5-t2-jammy.iso.01"]
+    },
+    {
+      "name": "NixOS Gnome",
+      "iso": ["https://github.com/t2linux/nixos-t2-iso/releases/download/v6.4.9-3/t2-iso-gnome.iso-part-00", "https://github.com/t2linux/nixos-t2-iso/releases/download/v6.4.9-3/t2-iso-gnome.iso-part-01", "https://github.com/t2linux/nixos-t2-iso/releases/download/v6.4.9-3/t2-iso-gnome.iso-part-02"]
+    },
+    {
+      "name": "NixOS Minimal",
+      "iso": ["https://github.com/t2linux/nixos-t2-iso/releases/download/v6.4.9-3/t2-iso-minimal.iso-part-00"]
+    },
+    {
+      "name": "Ubuntu (Jammy)",
+      "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-22.04-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-22.04-6.9.5-t2-jammy.iso.00"]
+    },
+    {
+      "name": "Ubuntu (Noble)",
+      "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-24.04-6.9.5-t2-noble.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-24.04-6.9.5-t2-noble.iso.01"]
+    }
+  ]
+}

--- a/docs/tools/distro-metadata.json
+++ b/docs/tools/distro-metadata.json
@@ -22,6 +22,14 @@
       "iso": ["https://github.com/t2linux/fedora-iso/releases/download/f40.0/t2linux-fedora-live-sway-40.iso"]
     },
     {
+      "name": "Ubuntu (Jammy)",
+      "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-22.04-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-22.04-6.9.5-t2-jammy.iso.00"]
+    },
+    {
+      "name": "Ubuntu (Noble)",
+      "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-24.04-6.9.5-t2-noble.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-24.04-6.9.5-t2-noble.iso.01"]
+    },
+    {
       "name": "Kubuntu (Jammy)",
       "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-22.04-6.9.5-t2-jammy.iso.00","https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/kubuntu-22.04-6.9.5-t2-jammy.iso.01"]
     },
@@ -48,14 +56,6 @@
     {
       "name": "NixOS Minimal",
       "iso": ["https://github.com/t2linux/nixos-t2-iso/releases/download/v6.4.9-3/t2-iso-minimal.iso-part-00"]
-    },
-    {
-      "name": "Ubuntu (Jammy)",
-      "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-22.04-6.9.5-t2-jammy.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-22.04-6.9.5-t2-jammy.iso.00"]
-    },
-    {
-      "name": "Ubuntu (Noble)",
-      "iso": ["https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-24.04-6.9.5-t2-noble.iso.00", "https://github.com/t2linux/T2-Ubuntu/releases/download/v6.9.5-1/ubuntu-24.04-6.9.5-t2-noble.iso.01"]
     }
   ]
 }


### PR DESCRIPTION
This is for a gui installer I am writing, I wanted a parsable list of ISOs and distros. It has every ISO from the preinstall guide except for gentoo and blendos. This needs to be updated whenever you release a new ISO.

`iso_compression` should be `zip` if the ISO file is the only file inside of a zip archive. If the ISO is *not* compressed then the `iso_compression` field should not appear (it should not be null or empty).
```
{
  "all": [
    {
      "name": "user visible disto name",
      "iso": ["url to iso download", "appended in order to the first file"],
      "iso_compression": "zip",
    }
  ]
}
```