### PR TITLE
Update index.html for MacPro7,1 w/ IFL

### DIFF
--- a/state/index.html
+++ b/state/index.html
@@ -1654,7 +1654,7 @@
 <td>MacPro7,1</td>
 <td>🟡 Partially working</td>
 <td></td>
-<td>Users have encountered PCIE Address Space issues, with auto remap breaking.</td>
+<td>Users have encountered PCIE Address Space issues, with auto remap breaking. If present, removing an Infinity Fabric Link Bridge or an Infinity Fabric Link Jumper from the GPU(s) may solve the PCIE Address Space issues.</td>
 <td></td>
 </tr>
 <tr>


### PR DESCRIPTION
For MacPro7,1, a temporary solution may be possible by removing the Infinity Fabric Link (Bridge or Jumper) from the GPU(s)