### PR TITLE
Add Gentoo/OpenRC suspend workaround

### DIFF
--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -205,9 +205,9 @@ Prerequisites:
 
 For T2 MacBooks, while unloading only the apple-bce module is sufficient for basic suspend functionality, additional module handling may be required depending on your model:
 
-- All T2 models require the apple-bce module handling
-- For models with Touch Bar, a specific module sequence (apple_bce -> hid_appletb_bl -> hid_appletb_kbd -> appletbdrm) is required to properly reinitialize the Touch Bar device after resume
-- If you use tiny-dfr for Touch Bar customization, the tiny-dfr service needs to be stopped before suspend and started after resume
+- All T2 models require the apple-bce module handling.
+- For models with Touch Bar, a specific module sequence (apple_bce -> hid_appletb_bl -> hid_appletb_kbd) is required to properly reinitialize the Touch Bar device after resume.
+- If you use tiny-dfr for Touch Bar customization, the tiny-dfr service needs to be stopped before suspend and started after resume, and appletbdrm module is required.
 
 The script below includes all cases with commented sections. Uncomment the relevant sections based on your model and requirements. The loading order of modules is important for proper device initialization after resume.
 
@@ -222,11 +222,11 @@ The script below includes all cases with commented sections. Uncomment the relev
 
          # Uncomment the following if using tiny dfr for touchbar
          #/etc/init.d/tiny-dfr stop
-         #rmmod -r appletbdrm
+         #modprobe -r appletbdrm
      
          # Uncomment the following for models with touchbar but not using tiny dfr
-         #rmmod -r hid_appletb_kbd
-         #rmmod -r hid_appletb_bl
+         #modprobe -r hid_appletb_kbd
+         #modprobe -r hid_appletb_bl
          ;;
        
        post/*)

--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -224,7 +224,7 @@ The script below includes all cases with commented sections. Uncomment the relev
          #/etc/init.d/tiny-dfr stop
          #modprobe -r appletbdrm
      
-         # Uncomment the following for models with touchbar but not using tiny dfr
+         # Uncomment the following for models with touchbar, irrespective of whether using tiny-dfr
          #modprobe -r hid_appletb_kbd
          #modprobe -r hid_appletb_bl
          ;;
@@ -234,7 +234,7 @@ The script below includes all cases with commented sections. Uncomment the relev
          sleep 4 
          modprobe apple_bce
          
-         # Uncomment the following for models with touchbar but not using tiny dfr
+         # Uncomment the following for models with touchbar, irrespective of whether using tiny-dfr
          #sleep 4
          #modprobe hid_appletb_bl
          #sleep 2

--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -144,7 +144,7 @@ Please note that this internal ethernet interface is required for various servic
 
 # Suspend Workaround
 
-### Arch based distros
+## Arch based distros
 
 S3 suspend has been broken since macOS Sonoma, it has never been fixed, but this workaround will make deep suspend work. Currently this workaround works only on Arch based distros.
 
@@ -190,7 +190,7 @@ S3 suspend has been broken since macOS Sonoma, it has never been fixed, but this
     Make sure you have `CONFIG_MODULE_FORCE_UNLOAD=y` in the kernel config.
     To check, run: `zcat /proc/config.gz | grep "CONFIG_MODULE_FORCE_UNLOAD"` on Arch based distros.
 
-### Gentoo/OpenRC
+## Gentoo/OpenRC
 
 S3 suspend has been broken since macOS Sonoma, it has never been fixed, but this workaround will make deep suspend work on Gentoo Linux using OpenRC and elogind.
 

--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -145,6 +145,7 @@ Please note that this internal ethernet interface is required for various servic
 # Suspend Workaround
 
 ### Arch based distros
+
 S3 suspend has been broken since macOS Sonoma, it has never been fixed, but this workaround will make deep suspend work. Currently this workaround works only on Arch based distros.
 
 1. Create and edit this file: `/etc/systemd/system/suspend-fix-t2.service`
@@ -194,11 +195,13 @@ S3 suspend has been broken since macOS Sonoma, it has never been fixed, but this
 S3 suspend has been broken since macOS Sonoma, it has never been fixed, but this workaround will make deep suspend work on Gentoo Linux using OpenRC and elogind.
 
 Prerequisites:
+
 1. Make sure elogind is installed and running:
-    ```bash
-    rc-update add elogind boot
-    rc-service elogind start
-    ```
+
+     ```bash
+     rc-update add elogind boot
+     rc-service elogind start
+     ```
 
 For T2 MacBooks, while unloading only the apple-bce module is sufficient for basic suspend functionality, additional module handling may be required depending on your model:
 
@@ -209,42 +212,48 @@ For T2 MacBooks, while unloading only the apple-bce module is sufficient for bas
 The script below includes all cases with commented sections. Uncomment the relevant sections based on your model and requirements. The loading order of modules is important for proper device initialization after resume.
 
 1. Create and edit this file: `/etc/elogind/system-sleep/apple-bce-handler`
-    ```bash
-    #!/bin/bash
-    case $1/$2 in
-      pre/*)
-        # Required for all T2 models
-        rmmod -f apple_bce
-        
-        # Uncomment the following for models with Touch Bar
-        #rmmod -f appletbdrm
-        #rmmod -f hid_appletb_kbd
-        #rmmod -f hid_appletb_bl
-        
-        # Uncomment the following if using tiny-dfr
-        #/etc/init.d/tiny-dfr stop
-        #killall -9 tiny-dfr 2>/dev/null
-        ;;
-      
-      post/*)
-        # Required for all T2 models
-        sleep 4 
-        modprobe apple_bce
-        
-        # Uncomment the following for models with Touch Bar
-        #sleep 4
-        #modprobe hid_appletb_bl
-        #sleep 2
-        #modprobe hid_appletb_kbd
-        #sleep 2
-        #modprobe appletbdrm
-        
-        # Uncomment the following if using tiny-dfr
-        #sleep 3
-        #/etc/init.d/tiny-dfr start
-        ;;
-    esac
-    ```
+
+     ```bash
+     #!/bin/bash
+     case $1/$2 in
+       pre/*)
+         # Required for all T2 models
+         rmmod -f apple_bce
+         
+         # Uncomment the following for models with touchbar but not using tiny dfr
+         #rmmod -f appletbdrm
+         #rmmod -f hid_appletb_kbd
+         #rmmod -f hid_appletb_bl
+         
+         # Uncomment the following if using tiny dfr for touchbar
+         #/etc/init.d/tiny-dfr stop
+         ;;
+       
+       post/*)
+         # Required for all T2 models
+         sleep 4 
+         modprobe apple_bce
+         
+         # Uncomment the following for models with touchbar but not using tiny dfr
+         #sleep 4
+         #modprobe hid_appletb_bl
+         #sleep 2
+         #modprobe hid_appletb_kbd
+         #sleep 2
+         #modprobe appletbdrm
+         
+         # Uncomment the following if using tiny dfr for touchbar
+         #sleep 3
+         #/etc/init.d/tiny-dfr start
+         ;;
+     esac
+     ```
+
+2. Make the script executable:
+
+     ```bash
+     chmod +x /etc/elogind/system-sleep/apple-bce-handler
+     ```
 
 !!! note
    Make sure you have CONFIG_MODULE_FORCE_UNLOAD=y in the kernel config.

--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -219,14 +219,14 @@ The script below includes all cases with commented sections. Uncomment the relev
        pre/*)
          # Required for all T2 models
          rmmod -f apple_bce
-         
-         # Uncomment the following for models with touchbar but not using tiny dfr
-         #rmmod -f appletbdrm
-         #rmmod -f hid_appletb_kbd
-         #rmmod -f hid_appletb_bl
-         
+
          # Uncomment the following if using tiny dfr for touchbar
          #/etc/init.d/tiny-dfr stop
+         #rmmod -r appletbdrm
+     
+         # Uncomment the following for models with touchbar but not using tiny dfr
+         #rmmod -r hid_appletb_kbd
+         #rmmod -r hid_appletb_bl
          ;;
        
        post/*)
@@ -239,10 +239,10 @@ The script below includes all cases with commented sections. Uncomment the relev
          #modprobe hid_appletb_bl
          #sleep 2
          #modprobe hid_appletb_kbd
-         #sleep 2
-         #modprobe appletbdrm
          
          # Uncomment the following if using tiny dfr for touchbar
+         #sleep 2
+         #modprobe appletbdrm
          #sleep 3
          #/etc/init.d/tiny-dfr start
          ;;
@@ -256,4 +256,4 @@ The script below includes all cases with commented sections. Uncomment the relev
      ```
 
 !!! note
-   Make sure you have CONFIG_MODULE_FORCE_UNLOAD=y in the kernel config.
+    Make sure you have CONFIG_MODULE_FORCE_UNLOAD=y in the kernel config.


### PR DESCRIPTION
Add suspend workaround for Gentoo Linux using OpenRC and elogind, including Touch Bar reinitialization after resume.