### PR TITLE
NixOS: fix declarative firmware setup code

### DIFF
--- a/docs/distributions/nixos/installation.md
+++ b/docs/distributions/nixos/installation.md
@@ -336,6 +336,7 @@ The declarative setup is suitable for long-term use after you have installed Nix
         (pkgs.stdenvNoCC.mkDerivation (final: {
           name = "brcm-firmware";
           src = ./firmware/brcm;
+          phases = [ "installPhase" ];
           installPhase = ''
             mkdir -p $out/lib/firmware/brcm
             cp ${final.src}/* "$out/lib/firmware/brcm"


### PR DESCRIPTION
- the added line specifies to only run the installPhase when building the derivation.
- this is fine since we don't need other phases here
- this fixes an otherwise returned error about the unpackPhase not being defined