### PR TITLE
Wifi Bluetooth Guide Update

### DIFF
--- a/docs/guides/wifi-bluetooth.md
+++ b/docs/guides/wifi-bluetooth.md
@@ -11,7 +11,7 @@ This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs.
     NixOS users please first read the [distribution specific guide on firmware](../distributions/nixos/installation.md#wi-fi-and-bluetooth-setup) before following instructions on this page.
 
 !!! Warning: "Wifi Backend"
-There is currently an upstream issue with `wpa_supplicant` Backend. Please use `iwd` instead until the issue is resolved.
+There is currently an upstream issue with `wpa_supplicant`. Please use `iwd` instead until the issue is resolved.
 
 ## Ensure Kernel Supports OTP Firmware Selection
 

--- a/docs/guides/wifi-bluetooth.md
+++ b/docs/guides/wifi-bluetooth.md
@@ -11,7 +11,7 @@ This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs.
     NixOS users please first read the [distribution specific guide on firmware](../distributions/nixos/installation.md#wi-fi-and-bluetooth-setup) before following instructions on this page.
 
 !!! Warning: "Wifi Backend"
-There is currently an upstream issue with `wpa_supplicant`. Please use `iwd` instead until the issue is resolved.
+There is currently an upstream issue with `wpa_supplicant`. Please use `iwd` instead until the issue is resolved (Note: Not necessary for Fedora).
 
 ## Ensure Kernel Supports OTP Firmware Selection
 

--- a/docs/guides/wifi-bluetooth.md
+++ b/docs/guides/wifi-bluetooth.md
@@ -11,7 +11,7 @@ This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs.
     NixOS users please first read the [distribution specific guide on firmware](../distributions/nixos/installation.md#wi-fi-and-bluetooth-setup) before following instructions on this page.
 
 !!! Warning: "Wifi Backend"
-There is currently an upstream issue with `wpa_supplicant`. Please use `iwd` instead until the issue is resolved.
+There is currently an upstream issue with `wpa_supplicant` Backend. Please use `iwd` instead until the issue is resolved.
 
 ## Ensure Kernel Supports OTP Firmware Selection
 

--- a/docs/guides/wifi-bluetooth.md
+++ b/docs/guides/wifi-bluetooth.md
@@ -10,6 +10,9 @@ This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs.
 !!! Warning "NixOS"
     NixOS users please first read the [distribution specific guide on firmware](../distributions/nixos/installation.md#wi-fi-and-bluetooth-setup) before following instructions on this page.
 
+!!! Warning: "Wifi Backend"
+There is currently an upstream issue with `wpa_supplicant`. Please use `iwd` instead until the issue is resolved.
+
 ## Ensure Kernel Supports OTP Firmware Selection
 
 Check if this command outputs any lines: `modinfo brcmfmac | grep 4387` If it doesn't output anything, then upgrade your kernel.

--- a/docs/guides/wifi-bluetooth.md
+++ b/docs/guides/wifi-bluetooth.md
@@ -4,14 +4,14 @@
 
 This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs. This guide is also applicable to **iMac19,1** and **iMac19,2**, which are T1 Intel Macs. This guide is NOT applicable for the rest of the T1 and older Intel Macs.
 
+!!! Bug: "Unable to connect to Wi-Fi even after entering correct password"
+    Due to a [regression](https://lists.infradead.org/pipermail/hostap/2024-August/042893.html) since **wpa_supplicant 2.11**, Wi-Fi on broadcom chips is broken, thus affecting the T2 Macs as well. Please use [iwd](https://wiki.archlinux.org/title/NetworkManager#Using_iwd_as_the_Wi-Fi_backend) instead until the issue is resolved. Currently, only Arch Linux and EndeavourOS are affected.
+
 !!! Warning "Arch/EndeavourOS"
-    If you're running Arch or EndeavourOS and have `apple-bcm-firmware` installed, you do not need to follow this guide.
+    If you're running Arch or EndeavourOS and have `apple-bcm-firmware` installed, you do not need to follow this guide further.
 
 !!! Warning "NixOS"
     NixOS users please first read the [distribution specific guide on firmware](../distributions/nixos/installation.md#wi-fi-and-bluetooth-setup) before following instructions on this page.
-
-!!! Warning: "Wifi Backend"
-There is currently an upstream issue with `wpa_supplicant`. Please use `iwd` instead until the issue is resolved (Note: Not necessary for Fedora).
 
 ## Ensure Kernel Supports OTP Firmware Selection
 

--- a/docs/guides/wifi-bluetooth.md
+++ b/docs/guides/wifi-bluetooth.md
@@ -4,7 +4,7 @@
 
 This page is a step by step guide to get Wi-Fi and Bluetooth working on T2 Macs. This guide is also applicable to **iMac19,1** and **iMac19,2**, which are T1 Intel Macs. This guide is NOT applicable for the rest of the T1 and older Intel Macs.
 
-!!! Bug: "Unable to connect to Wi-Fi even after entering correct password"
+!!! Bug "Unable to connect to Wi-Fi even after entering correct password"
     Due to a [regression](https://lists.infradead.org/pipermail/hostap/2024-August/042893.html) since **wpa_supplicant 2.11**, Wi-Fi on broadcom chips is broken, thus affecting the T2 Macs as well. Please use [iwd](https://wiki.archlinux.org/title/NetworkManager#Using_iwd_as_the_Wi-Fi_backend) instead until the issue is resolved. Currently, only Arch Linux and EndeavourOS are affected.
 
 !!! Warning "Arch/EndeavourOS"


### PR DESCRIPTION
## Description
This PR replaces `wpa_supplicant` with `iwd` as the Wi-Fi backend due to an upstream issue with `wpa_supplicant`. The change ensures a more stable and reliable Wi-Fi connection for users.

## Changes 
Added a warning message in the documentation to alert users about the `wpa_supplicant `issue.
Recommended `iwd` as the preferred Wi-Fi backend until the issue is resolved.
## Why this change is necessary
There is a known upstream issue with `wpa_supplicant` that may cause instability or connectivity problems.
`iwd` is a modern and reliable alternative that can help users avoid these issues.
This warning ensures users are aware of the problem 
## Possible Addition
I could add a guide at the bottom of the page to advise user how to fix the issue if wanted
