### PR TITLE
Update get-apple-firmware.service activation logic

### DIFF
--- a/docs/tools/get-apple-firmware.service
+++ b/docs/tools/get-apple-firmware.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=Get Apple WiFi and Bluetooth firmware
-ConditionFirstBoot=yes
+ConditionPathExists=!/etc/get_apple_firmware_attempted
 ConditionPathExists=/lib/firmware/brcm
-Wants=first-boot-complete.target
-Before=first-boot-complete.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/libexec/get-apple-firmware -i get_from_macos
+ExecStart=-/usr/libexec/get-apple-firmware -i get_from_macos
+ExecStart=touch /etc/get_apple_firmware_attempted
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This creates the file /etc/get_apple_firmware_attempted when the service is activated. The service will only activate when this file is *not* present. The service will run once on first boot and will disable itself after, regardless of the exit status of the firmware script. This change should make the service actually start on most distros since many do not follow systemd first-boot conventions.