### PR TITLE
Remove link's to mikeeq's fedora iso/kernel

### DIFF
--- a/docs/distributions/fedora/installation.md
+++ b/docs/distributions/fedora/installation.md
@@ -1,8 +1,6 @@
 # Download the latest safe release
 
-Many thanks to Mike for building. You can download a live iso from Mikeeq [here](https://github.com/mikeeq/mbp-fedora).
-
-If you need a more updated kernel, use the iso from [sharpenedblade](https://github.com/t2linux/fedora-iso/releases). Remember to follow the [Wi-Fi guide](https://wiki.t2linux.org/guides/wifi-bluetooth/).
+Many thanks to Mike for building. You can download a live iso from [here](https://github.com/t2linux/fedora-iso/releases).
 
 # Hardware Requirements
 

--- a/docs/distributions/fedora/installation.md
+++ b/docs/distributions/fedora/installation.md
@@ -1,6 +1,6 @@
 # Download the latest safe release
 
-Many thanks to Mike for building. You can download a live iso from [here](https://github.com/t2linux/fedora-iso/releases).
+Many thanks to [Mike](https://github.com/mikeeq/) for building. You can download a live iso from [here](https://github.com/t2linux/fedora-iso/releases).
 
 # Hardware Requirements
 

--- a/docs/guides/postinstall.md
+++ b/docs/guides/postinstall.md
@@ -22,7 +22,6 @@ Many distro maintainers provide compiled kernels which can be installed on your 
 | ----------------------------------- | ---------------------- |
 | Arch based distros                  | <https://github.com/NoaHimesaka1873/linux-t2-arch> |
 | Arch based distros (Xanmod kernels) | <https://github.com/NoaHimesaka1873/linux-xanmod-edge-t2> |
-| Fedora                              | <https://github.com/mikeeq/mbp-fedora-kernel> |
 | Fedora                              | <https://github.com/t2linux/fedora-kernel> |
 | Gentoo                              | <https://github.com/t2linux/T2-Gentoo-Kernel> |
 | Manjaro                             | <https://github.com/NoaHimesaka1873/manjaro-kernel-t2> |

--- a/docs/guides/preinstall.md
+++ b/docs/guides/preinstall.md
@@ -31,7 +31,6 @@ Listed below are the currently available installer ISOs for download:
 | blendOS                 | <https://blendos.co/install/t2/> |
 | CachyOS                 | <https://cachyos.org> |
 | EndeavourOS             | <https://github.com/t2linux/EndeavourOS-ISO-t2/releases/latest> |
-| Fedora                  | <https://github.com/mikeeq/mbp-fedora> |
 | Fedora                  | <https://github.com/t2linux/fedora-iso/releases/latest> |
 | Gentoo                  | Please refer to this [page](https://wiki.t2linux.org/distributions/gentoo/installation/) |
 | Manjaro                 | <https://github.com/NoaHimesaka1873/manjaroiso-t2/releases/latest> |

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,6 @@ If the distribution you want to use has a guide [here](https://wiki.t2linux.org/
 
 - Arch [https://github.com/t2linux/archiso-t2](https://github.com/t2linux/archiso-t2)
 - EndeavourOS [https://github.com/t2linux/EndeavourOS-ISO-t2](https://github.com/t2linux/EndeavourOS-ISO-t2)
-- Fedora [https://github.com/mikeeq/mbp-fedora](https://github.com/mikeeq/mbp-fedora)
 - Fedora [https://github.com/t2linux/fedora-iso](https://github.com/t2linux/fedora-iso)
 - Gentoo [https://github.com/t2linux/T2-Gentoo-Kernel](https://github.com/t2linux/T2-Gentoo-Kernel)
 - Manjaro [https://github.com/NoaHimesaka1873/manjaroiso-t2](https://github.com/NoaHimesaka1873/manjaroiso-t2)


### PR DESCRIPTION
Both repo's have an end of development notice and are no longer actively maintained.