### PR TITLE
Add fedora faq entry about upgrades

### DIFF
--- a/docs/distributions/fedora/faq.md
+++ b/docs/distributions/fedora/faq.md
@@ -10,13 +10,13 @@ This may be due to differences between USB-C to USB-A adapters. Try a different 
 
 Follow the instructions in the [post-install guide](https://wiki.t2linux.org/guides/postinstall/#setting-up-the-touch-bar). If it still is not working, try updating your macOS instalation.
 
-# My keyboard won't light up (only applies to some hardware)
-
-This sometimes doesn't work on Fedora, we are working on a fix. For now, you can't really do anything about it. This is only affects the internal Apple keyboard, it **will not** affect your external keyboard. This also only occurs on Fedora, the backlight works on all other ditros.
-
 # I get an error about the bootloader when installing
 
 Download the latest ISO, then try again. Make sure you are using the T2 Fedora iso.
+
+# Major version upgrades are not working
+
+If you try to upgrade to a new stable release (ex: f42 -> f43), and you reboot into the same version as before, run `sudo touch /usr/lib/clock-epoch`, then try to upgrade again.
 
 # My Wi-Fi stops working after suspending
 


### PR DESCRIPTION
A lot of users had issues with the RTC not working and chrony not starting during offline upgrades, so certificate validation was failing. Also the backlight issue is fixed now.