### PR TITLE
move uninstall guide to bottom of list

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,11 +87,11 @@ nav:
           - Windows Triple Boot: guides/windows.md
           - Hybrid Graphics: guides/hybrid-graphics.md
           - Audio: guides/audio-config.md
-          - Uninstall: guides/uninstall.md
           - Fan: guides/fan.md
           - Kernel: guides/kernel.md
           - Startup Manager: guides/startup-manager.md
           - rEFInd: guides/refind.md
+          - Uninstall: guides/uninstall.md
     - Distributions:
           - Overview: distributions/overview.md
           - Arch:


### PR DESCRIPTION
I noticed the uninstall guide is in the middle of the list of guides.

I'm not sure if they're in a specific order (they seem to be) but it would make sense for uninstall to be at the bottom as it's probably the last thing you'd do and the least useful for people trying to install.