### PR TITLE
Link rEFInd boot settings from the audio guide

### DIFF
--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -40,7 +40,7 @@ If your distro uses PulseAudio by default, consider switching to PipeWire with r
 !!!note "Switching to headphones automatically"
     If you want headphones to be switched to automatically when they are plugged in, you should set them as the default audio sink using the settings app of your DE, `pavucontrol`, `pactl` or `wpctl`.
 
-# Internal microphones DSP configuration
+# Internal microphones DSP Configuration
 
 In order adjust the microphones signal automatically, we can use the following Pipewire filterchain config:
 

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -19,6 +19,9 @@ If not present, you'll have to update your bootup kernel parameters:
 
 !!!note "systemd-boot"
     If you use systemd-boot you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pm_async=off` to the options line. The files to edit will have the `.conf` extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
+    
+!!!note "rEFInd"
+    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](guides/refind/#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
 
 # Audio Configuration Files
 
@@ -29,6 +32,7 @@ sudo git clone https://github.com/kekrby/t2-better-audio.git /tmp/t2-better-audi
 cd /tmp/t2-better-audio
 ./install.sh
 sudo rm -r /tmp/t2-better-audio
+cd -
 ```
 
 If your distro uses PulseAudio by default, consider switching to PipeWire with rtkit for the best possible experience. You can still use PulseAudio but the experience will not be as smooth as PipeWire, for example you might not be able to select the speakers as the output device when headphones are plugged in.
@@ -36,7 +40,7 @@ If your distro uses PulseAudio by default, consider switching to PipeWire with r
 !!!note "Switching to headphones automatically"
     If you want headphones to be switched to automatically when they are plugged in, you should set them as the default audio sink using the settings app of your DE, `pavucontrol`, `pactl` or `wpctl`.
 
-# Internal microphones DSP Configuration.
+# Internal microphones DSP configuration
 
 In order adjust the microphones signal automatically, we can use the following Pipewire filterchain config:
 

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -19,7 +19,7 @@ If not present, you'll have to update your bootup kernel parameters:
 
 !!!note "systemd-boot"
     If you use systemd-boot you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pm_async=off` to the options line. The files to edit will have the `.conf` extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
-    
+
 !!!note "rEFInd"
     If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](guides/refind/#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
 


### PR DESCRIPTION
Also:
- move back from now-erased t2-better-audio folder in the suggested bash script
- fix title formatting to comply with the others

------

In my case, the original audio guide suggesting to edit GRUB stuff didn't help with `/proc/cmdline`, but after creating `refind_linux.conf` and adding the proper options there, it did the trick.
That doesn't mean I got audio to work, but at least the correct boot options are now showing up :joy: 