### PR TITLE
docs: update t2bce audio configuration guidance

### DIFF
--- a/docs/distributions/gentoo/installation.md
+++ b/docs/distributions/gentoo/installation.md
@@ -30,6 +30,7 @@
     2. Alternatively, you can use the kernel sources and manually compile. With this method, the update process is not automated, and manual configuration is necessary. However, `sys-kernel/t2gentoo-sources` tends to get new kernel versions faster than `sys-kernel/t2gentoo-kernel`. To install it, run: `emerge -av sys-kernel/t2gentoo-sources`. After installing the kernel sources, run `eselect kernel set 1` to point `/usr/src/linux` to the correct path, then follow the directions in the [Manual Configuration](https://wiki.gentoo.org/wiki/Handbook:AMD64/Installation/Kernel#Alternative:_Manual_configuration) section of the handbook. If you decide to manually configure your kernel, make sure the following options are set:
 
         ```bash
+        CONFIG_T2BCE_DMA=m
         CONFIG_T2BCE_CORE=m
         CONFIG_T2BCE_VHCI=m
         CONFIG_T2BCE_AUDIO=m

--- a/docs/distributions/ubuntu/faq.md
+++ b/docs/distributions/ubuntu/faq.md
@@ -20,15 +20,6 @@ We've now changed the GRUB Bootloader settings, but we now need to update GRUB t
 
 If you already have Bootcamp installed, you might notice that the boot option for Bootcamp instead boots you into Ubuntu. This is because GRUB automatically shares with a Windows installation. Follow [this guide on triple booting](https://wiki.t2linux.org/guides/windows/#if-windows-is-installed-first) to get Windows working again.
 
-# Why isn't sound working?
-
-Ensure that PipeWire and the T2 audio configuration package are installed and up to date:
-
-```bash
-sudo apt update
-sudo apt install pipewire wireplumber apple-t2-audio-config
-```
-
 Restart after installing or updating the audio configuration.
 
 # How do I upgrade my kernel

--- a/docs/distributions/ubuntu/faq.md
+++ b/docs/distributions/ubuntu/faq.md
@@ -20,8 +20,6 @@ We've now changed the GRUB Bootloader settings, but we now need to update GRUB t
 
 If you already have Bootcamp installed, you might notice that the boot option for Bootcamp instead boots you into Ubuntu. This is because GRUB automatically shares with a Windows installation. Follow [this guide on triple booting](https://wiki.t2linux.org/guides/windows/#if-windows-is-installed-first) to get Windows working again.
 
-Restart after installing or updating the audio configuration.
-
 # How do I upgrade my kernel
 
 Follow [these](https://github.com/t2linux/T2-Debian-and-Ubuntu-Kernel?tab=readme-ov-file#using-the-apt-repo) instructions.

--- a/docs/distributions/ubuntu/faq.md
+++ b/docs/distributions/ubuntu/faq.md
@@ -22,14 +22,14 @@ If you already have Bootcamp installed, you might notice that the boot option fo
 
 # Why isn't sound working?
 
-On **Ubuntu 22.04 or earlier**, PulseAudio is installed by default, which performs really badly with T2 audio configuration files. It is suggested to [switch to PipeWire](https://linuxconfig.org/how-to-install-pipewire-on-ubuntu-linux) for better performance, although its still bad as compared to Ubuntu 22.10, which has native support for PipeWire.
-
-On **Ubuntu 22.10 or later**, PipeWire is supported natively and works just fine with audio configuration files. Still, it's recommended to use the upstream version of PipeWire since it is found to perform better and has more features than the native one. You can run the following commands to use the upstream version:
+Ensure that PipeWire and the T2 audio configuration package are installed and up to date:
 
 ```bash
-sudo add-apt-repository ppa:pipewire-debian/pipewire-upstream
-sudo apt install pipewire pipewire-audio-client-libraries libpipewire-0.3-modules libspa-0.2-{bluetooth,jack,modules} pipewire{,-{audio-client-libraries,pulse,bin,tests}}
+sudo apt update
+sudo apt install pipewire wireplumber apple-t2-audio-config
 ```
+
+Restart after installing or updating the audio configuration.
 
 # How do I upgrade my kernel
 

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -21,7 +21,7 @@ If not present, you'll have to update your bootup kernel parameters:
     If you use systemd-boot you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pm_async=off` to the options line. The files to edit will have the `.conf` extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
 
 !!!note "rEFInd"
-    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](refind.md#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
+    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](refind#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
 
 # Audio Configuration Files
 

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -21,55 +21,27 @@ If not present, you'll have to update your bootup kernel parameters:
     If you use systemd-boot you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pm_async=off` to the options line. The files to edit will have the `.conf` extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
 
 !!!note "rEFInd"
-    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](guides/refind/#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
+    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](refind.md#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
 
 # Audio Configuration Files
 
-Simply run the following to set up audio:
+The `t2bce_audio` kernel driver exposes the audio devices, but userspace audio
+profiles are also required. Install the `apple-t2-audio-config` package from
+your distribution's T2 repository. Distribution-specific installation guides
+normally include this package already.
+
+If your distribution does not provide the package, install the profiles
+manually:
 
 ```bash
-sudo git clone https://github.com/kekrby/t2-better-audio.git /tmp/t2-better-audio
+git clone https://github.com/kekrby/t2-better-audio.git /tmp/t2-better-audio
 cd /tmp/t2-better-audio
 ./install.sh
-sudo rm -r /tmp/t2-better-audio
 cd -
+rm -r /tmp/t2-better-audio
 ```
 
 If your distro uses PulseAudio by default, consider switching to PipeWire with rtkit for the best possible experience. You can still use PulseAudio but the experience will not be as smooth as PipeWire, for example you might not be able to select the speakers as the output device when headphones are plugged in.
 
 !!!note "Switching to headphones automatically"
     If you want headphones to be switched to automatically when they are plugged in, you should set them as the default audio sink using the settings app of your DE, `pavucontrol`, `pactl` or `wpctl`.
-
-# Internal microphones DSP Configuration
-
-In order adjust the microphones signal automatically, we can use the following Pipewire filterchain config:
-
-[Microphones config instructions](https://github.com/lemmyg/t2-apple-audio-dsp/tree/mic)
-
-# Issues
-
-- Some people are unable to get audio input to work. You may have to use a separate microphone.
-
-## KDE
-
-The "Audio Volume" dialog / Audio in System Settings allow users to "Raise maximum volume", allowing to go past 100%. This
-does not offer a great deal of flexibility, it might work for getting acceptable recordings however.
-
-## EasyEffects with PipeWire
-
-[EasyEffects](https://github.com/wwmm/easyeffects) is a tool to control and modify audio streams when using PipeWire. Compared
-to the KDE approach mentioned above using input plugins like "Autogain" offers a lot more fine grain control and higher volume
-boosts.
-
-An EasyEffects preset (tested on MacBook Pro 15,1) is available [here](https://github.com/angelobdev/t2-easyeffects-preset).
-
-# Speakers
-
-All of apple's fancy tuning of the speakers is done in macOS, but a similar configuration is currently available for only the MacBook Pro 16 inch 2019.
-
-## MacBook Pro 16" 2019
-
-Currently we have an experimental DSP (Digital Signal Processing) config for MacBook Pro 16" 2019 with 6 speakers.
-Note that each model needs specific settings. Do not use it with other models as it could damage the speakers. Also do not expect same sound quality as in macOS.
-
-[DSP config instructions](https://github.com/lemmyg/t2-apple-audio-dsp/tree/speakers_161)

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -21,7 +21,7 @@ If not present, you'll have to update your bootup kernel parameters:
     If you use systemd-boot you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pm_async=off` to the options line. The files to edit will have the `.conf` extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
 
 !!!note "rEFInd"
-    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](refind#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
+    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](refind/#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
 
 # Audio Configuration Files
 

--- a/docs/guides/audio-config.md
+++ b/docs/guides/audio-config.md
@@ -21,24 +21,18 @@ If not present, you'll have to update your bootup kernel parameters:
     If you use systemd-boot you'll instead edit your boot conf files to add `intel_iommu=on iommu=pt pm_async=off` to the options line. The files to edit will have the `.conf` extension and be in the loader/entries/ folder on your EFI partition. This will most likely be `/boot/efi/loader/entries`
 
 !!!note "rEFInd"
-    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](refind/#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
+    If you use rEFInd, it may have been configured to boot directly onto Linux, without indirectly booting GRUB or systemd-boot. If that's the case, you'll have to edit the boot parameters somewhere else. Follow the steps at [Using rEFInd as a replacement for GRUB, systemd-boot, etc.](refind.md#using-refind-as-a-replacement-for-grub-systemd-boot-etc)
 
 # Audio Configuration Files
 
-The `t2bce_audio` kernel driver exposes the audio devices, but userspace audio
-profiles are also required. Install the `apple-t2-audio-config` package from
-your distribution's T2 repository. Distribution-specific installation guides
-normally include this package already.
-
-If your distribution does not provide the package, install the profiles
-manually:
+Simply run the following to set up audio:
 
 ```bash
-git clone https://github.com/kekrby/t2-better-audio.git /tmp/t2-better-audio
+sudo git clone https://github.com/kekrby/t2-better-audio.git /tmp/t2-better-audio
 cd /tmp/t2-better-audio
 ./install.sh
+sudo rm -r /tmp/t2-better-audio
 cd -
-rm -r /tmp/t2-better-audio
 ```
 
 If your distro uses PulseAudio by default, consider switching to PipeWire with rtkit for the best possible experience. You can still use PulseAudio but the experience will not be as smooth as PipeWire, for example you might not be able to select the speakers as the output device when headphones are plugged in.

--- a/docs/guides/hybrid-graphics.md
+++ b/docs/guides/hybrid-graphics.md
@@ -71,13 +71,15 @@ We can take this a step further and save substantial amounts of energy by deacti
    We can now run `sudo systemctl enable amdgpu-off.service` and reboot to disable our dGPU. This will decrease power draw on a MacBook significantly from around 20 to 9 Watts on idle using 50% display brightness, resulting in much longer battery life.
    Enabling the dGPU again is done using `sudo systemctl disable amdgpu-off.service` and reboot. A more convenient solution using aliases is explained in the next step.
 
-2. We can quickly disable, enable and check the current status of the dGPU by creating aliases. Simply execute the following block:
+2. We can quickly disable, enable and check the current status of the dGPU by creating persistent aliases. Add the following lines to `~/.bashrc`:
 
     ```plain
-    alias dgpu-off='sudo systemctl enable disable-amdgpu.service; sleep 2; sudo reboot'
-    alias dgpu-on='sudo systemctl disable disable-amdgpu.service; sleep 2; sudo reboot'
+    alias dgpu-off='sudo systemctl enable amdgpu-off.service; sleep 2; sudo reboot'
+    alias dgpu-on='sudo systemctl disable amdgpu-off.service; sleep 2; sudo reboot'
     alias dgpu-status='sudo cat /sys/kernel/debug/vgaswitcheroo/switch'
     ```
+
+   Start a new shell or run `source ~/.bashrc` to make the aliases available in the current shell.
 
    From now on you can check the status of the dGPU by simply entering `dgpu-status` :
 

--- a/docs/guides/kernel.md
+++ b/docs/guides/kernel.md
@@ -63,6 +63,7 @@ scripts/config --module CONFIG_BT_HCIBCM4377
 scripts/config --module CONFIG_HID_APPLETB_BL
 scripts/config --module CONFIG_HID_APPLETB_KBD
 scripts/config --module CONFIG_DRM_APPLETBDRM
+scripts/config --module CONFIG_T2BCE_DMA
 scripts/config --module CONFIG_T2BCE_CORE
 scripts/config --module CONFIG_T2BCE_VHCI
 scripts/config --module CONFIG_T2BCE_AUDIO


### PR DESCRIPTION
Prefer distribution-provided audio profiles and retain t2-better-audio only as a fallback. Remove outdated DSP recommendations and Ubuntu PipeWire PPA instructions, fix the rEFInd link, and include T2BCE_DMA in manual kernel configurations.